### PR TITLE
Replace ADMIN_KEY with Supabase admin authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Supabase (required for orders, inventory, flavor requests)
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Venmo handle for checkout (e.g. @LittleTownBakes)
+NEXT_PUBLIC_VENMO_HANDLE=@LittleTownBakes
+
+# Optional: Email provider (Resend/Postmark) - leave unset to skip notifications
+# RESEND_API_KEY=...
+# POSTMARK_API_KEY=...

--- a/DEV_TODO.md
+++ b/DEV_TODO.md
@@ -5,9 +5,10 @@
 - [ ] Create a Supabase project (no project configured yet)
 - [ ] Copy `.env.example` to `.env.local` and add:
   - `NEXT_PUBLIC_SUPABASE_URL` (from Project Settings → API)
+  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (from Project Settings → API)
   - `SUPABASE_SERVICE_ROLE_KEY` (from Project Settings → API)
-  - `ADMIN_KEY` (choose a secure secret)
   - `NEXT_PUBLIC_VENMO_HANDLE` (optional, e.g. @LittleTownBakes)
+- [ ] Create or invite the bakery owner under Authentication → Users and assign `app_metadata.role` to `admin` with the server-side Supabase Admin API (see README).
 - [ ] Run migrations in order (Supabase SQL Editor or CLI):
   1. `supabase/migrations/20250313000000_create_inventory_slots.sql`
   2. `supabase/migrations/20250313000001_create_flavor_requests.sql`

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ See [DEV_TODO.md](DEV_TODO.md) for a development checklist (Supabase project, mi
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Yes | Supabase publishable key used by cookie-backed Auth clients |
 | `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase service role key (server-only) |
-| `ADMIN_KEY` | Yes | Shared secret for admin API — sent as header `x-admin-key` (not Bearer) |
 | `NEXT_PUBLIC_VENMO_HANDLE` | No | Venmo handle for checkout (default: @LittleTownBakes) |
 
 ## Database
@@ -37,7 +37,18 @@ PostgreSQL tables `categories` and `products` are the authoritative catalog. Set
 
 Edit `public/about.json` for the About page (story, how to order, contact). See `CONTENT_ABOUT.md` for prompts and field descriptions.
 
-**Admin:** `/admin` redirects to `/admin/login`. After login, access orders, availability (menu availability per period), and flavor requests.
+**Admin:** `/admin` redirects to the protected admin area. Sign in at `/admin/login` with a Supabase Auth email/password account whose verified `app_metadata.role` is `admin`.
+
+## Admin provisioning and recovery
+
+Admin accounts must be managed through the Supabase Dashboard or trusted server-side tooling. Never run administrative Auth methods or use the service-role key in browser code.
+
+1. In Supabase Dashboard, open **Authentication → Users** and create the initial bakery owner with an email and temporary password. The equivalent trusted server-side method is `supabase.auth.admin.createUser`. Do not add public signup to this application.
+2. Copy the user ID, then use a trusted server-side script with `SUPABASE_SERVICE_ROLE_KEY` and `supabase.auth.admin.updateUserById(userId, { app_metadata: { role: "admin" } })`. Authorization uses `app_metadata`, never user-editable metadata.
+3. Add another admin later with the same Dashboard or server-side create-user process, then assign the same `app_metadata.role` value through the administrative API. Existing admins do not receive account-management UI in this application.
+4. Until a password-reset screen exists, a trusted operator can set a temporary password with `supabase.auth.admin.updateUserById(userId, { password: temporaryPassword })`, communicate it securely, and replace it again on request. Alternatively, add a dedicated recovery callback/update-password UX before issuing recovery links.
+
+The administrative client used for provisioning must remain in server-only tooling. The application keeps caller authentication separate from `lib/supabaseAdmin.ts`, which continues to perform privileged database operations only after the caller passes the server authorization check.
 
 ## Deployment
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Steps to get Little Town Bakes live. See `PRODUCTION_SETUP.md` for detailed inst
 - [ x] **Add Vercel env vars** (Settings → Environment Variables):
   - `NEXT_PUBLIC_SUPABASE_URL` — Supabase project URL
   - `SUPABASE_SERVICE_ROLE_KEY` — Supabase service role / secret key
-  - `ADMIN_KEY` — strong random string (e.g. `openssl rand -hex 32`)
+  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — Supabase publishable (anon) key for cookie-backed Auth
   - `NEXT_PUBLIC_VENMO_HANDLE` — e.g. `@LittleTownBakes`
 - [x ] **Redeploy** after adding env vars (or push a commit)
 
@@ -37,7 +37,7 @@ Steps to get Little Town Bakes live. See `PRODUCTION_SETUP.md` for detailed inst
 - [ ] **Place a test order** — confirm it appears in Supabase → Table Editor → `orders`
 - [ ] **Admin login** at `/admin/login` — verify orders, inventory, flavor requests load
 - [ ] **Submit a test flavor request** — confirm it appears in `flavor_requests`
-- [ ] **Share `ADMIN_KEY`** with client securely (e.g. password manager) for admin access
+- [ ] **Provision the admin account** — create the bakery owner under Supabase Authentication → Users and assign `app_metadata.role` to `admin` with the server-side Supabase Admin API (see README “Admin provisioning and recovery”). Authorization requires `app_metadata.role === "admin"`; there is no shared admin secret.
 
 ---
 

--- a/app/admin/availability/page.tsx
+++ b/app/admin/availability/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import type { InventorySlot } from "@/lib/inventory";
 import { getWeekStart, getMonthStart } from "@/lib/inventory";
 import { stringifyWeekTemplateCsv } from "@/lib/inventoryBulk";
+import { handleAdminAuthFailure } from "@/lib/adminResponse";
 
 /**
  * Admin page for setting menu availability: how many of each product
@@ -24,20 +25,20 @@ export default function AdminAvailabilityPage() {
 	const [bulkMessage, setBulkMessage] = useState<string | null>(null);
 	const [bulkError, setBulkError] = useState<string | null>(null);
 	const [bulkBusy, setBulkBusy] = useState(false);
+	const [pageError, setPageError] = useState<string | null>(null);
 
 	useEffect(() => {
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		if (!key) {
-			window.location.href = "/admin/login";
-			return;
-		}
-		const headers = { "x-admin-key": key };
-
 		Promise.all([
-			fetch("/api/admin/inventory", { headers }).then((r) => r.json()),
+			fetch("/api/admin/inventory"),
 			fetch("/api/menu").then((r) => r.json()),
 		])
-			.then(([slotsData, menuData]) => {
+			.then(async ([slotsResponse, menuData]) => {
+				if (!slotsResponse.ok) {
+					const authError = handleAdminAuthFailure(slotsResponse);
+					setPageError(authError ?? `Failed to load availability (${slotsResponse.status}).`);
+					return;
+				}
+				const slotsData = await slotsResponse.json();
 				setSlots(Array.isArray(slotsData) ? slotsData : []);
 				const items = (menuData?.items ?? []).map((i: { id: string; name: string }) => ({
 					id: i.id,
@@ -47,11 +48,6 @@ export default function AdminAvailabilityPage() {
 			})
 			.finally(() => setLoading(false));
 	}, []);
-
-	function adminHeaders(): HeadersInit {
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		return { "x-admin-key": key };
-	}
 
 	function triggerDownload(blob: Blob, filename: string) {
 		const url = URL.createObjectURL(blob);
@@ -67,10 +63,13 @@ export default function AdminAvailabilityPage() {
 		setBulkMessage(null);
 		setBulkBusy(true);
 		try {
-			const res = await fetch(`/api/admin/inventory/export?format=${format}`, {
-				headers: adminHeaders(),
-			});
+			const res = await fetch(`/api/admin/inventory/export?format=${format}`);
 			if (!res.ok) {
+				const authError = handleAdminAuthFailure(res);
+				if (authError) {
+					setBulkError(authError);
+					return;
+				}
 				const err = await res.json().catch(() => ({}));
 				setBulkError((err as { error?: string }).error ?? `Download failed (${res.status})`);
 				return;
@@ -105,11 +104,6 @@ export default function AdminAvailabilityPage() {
 	async function uploadBulkFile(file: File) {
 		setBulkError(null);
 		setBulkMessage(null);
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		if (!key) {
-			window.location.href = "/admin/login";
-			return;
-		}
 		setBulkBusy(true);
 		try {
 			const text = await file.text();
@@ -117,13 +111,17 @@ export default function AdminAvailabilityPage() {
 			const res = await fetch("/api/admin/inventory/bulk", {
 				method: "POST",
 				headers: {
-					"x-admin-key": key,
 					"Content-Type": isJson ? "application/json" : "text/csv",
 				},
 				body: text,
 			});
 			const data = await res.json().catch(() => ({}));
 			if (!res.ok) {
+				const authError = handleAdminAuthFailure(res);
+				if (authError) {
+					setBulkError(authError);
+					return;
+				}
 				setBulkError((data as { error?: string }).error ?? `Upload failed (${res.status})`);
 				return;
 			}
@@ -140,11 +138,13 @@ export default function AdminAvailabilityPage() {
 					`${errs.length} row(s) failed (${preview}${errs.length > 5 ? "…" : ""}). Successful rows were still saved.`
 				);
 			}
-			const headers = { "x-admin-key": key };
-			const slotsRes = await fetch("/api/admin/inventory", { headers });
+			const slotsRes = await fetch("/api/admin/inventory");
 			if (slotsRes.ok) {
 				const slotsData = await slotsRes.json();
 				setSlots(Array.isArray(slotsData) ? slotsData : []);
+			} else {
+				const authError = handleAdminAuthFailure(slotsRes);
+				if (authError) setBulkError(authError);
 			}
 		} finally {
 			setBulkBusy(false);
@@ -153,11 +153,11 @@ export default function AdminAvailabilityPage() {
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
-		const key = sessionStorage.getItem("admin_key") ?? "";
+		setPageError(null);
 		setSaving(true);
 		const res = await fetch("/api/admin/inventory", {
 			method: "POST",
-			headers: { "Content-Type": "application/json", "x-admin-key": key },
+			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(form),
 		});
 		setSaving(false);
@@ -183,7 +183,10 @@ export default function AdminAvailabilityPage() {
 				period_start: getWeekStart(now),
 				quantity_available: 0,
 			});
+			return;
 		}
+		const authError = handleAdminAuthFailure(res);
+		setPageError(authError ?? `Could not save availability (${res.status}).`);
 	}
 
 	const weekStart = getWeekStart(now);
@@ -203,6 +206,12 @@ export default function AdminAvailabilityPage() {
 			<p className="mb-6 text-sm text-sage">
 				Set how many of each product customers can order per week or month. This prevents overselling.
 			</p>
+
+			{pageError && (
+				<p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">
+					{pageError}
+				</p>
+			)}
 
 			<section className="card-warm mb-8 p-6 sm:p-8">
 				<h2 className="mb-2 font-display text-lg font-semibold text-cocoa">Bulk edit (CSV or JSON)</h2>

--- a/app/admin/flavor-requests/page.tsx
+++ b/app/admin/flavor-requests/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ChatNavIcon } from "@/components/icons/navIcons";
+import { handleAdminAuthFailure } from "@/lib/adminResponse";
 
 type FlavorRequest = {
 	id: string;
@@ -35,30 +36,41 @@ const STATUS_LABELS: Record<(typeof STATUS_OPTIONS)[number], { title: string; de
 export default function AdminFlavorRequestsPage() {
 	const [requests, setRequests] = useState<FlavorRequest[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		if (!key) {
-			window.location.href = "/admin/login";
-			return;
+		async function loadRequests() {
+			const response = await fetch("/api/admin/flavor-requests");
+			if (!response.ok) {
+				const authError = handleAdminAuthFailure(response);
+				if (authError) setError(authError);
+				else setError(`Failed to load flavor requests (${response.status}).`);
+				setLoading(false);
+				return;
+			}
+			const data = await response.json();
+			setRequests(Array.isArray(data) ? data : []);
+			setLoading(false);
 		}
-		fetch("/api/admin/flavor-requests", { headers: { "x-admin-key": key } })
-			.then((r) => r.json())
-			.then((data) => setRequests(Array.isArray(data) ? data : []))
-			.finally(() => setLoading(false));
+
+		void loadRequests();
 	}, []);
 
 	async function setStatus(id: string, status: string) {
-		const key = sessionStorage.getItem("admin_key") ?? "";
+		setError(null);
 		const res = await fetch("/api/admin/flavor-requests", {
 			method: "PATCH",
-			headers: { "Content-Type": "application/json", "x-admin-key": key },
+			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ id, status }),
 		});
 		if (res.ok) {
 			const updated = await res.json();
 			setRequests((prev) => prev.map((r) => (r.id === id ? updated : r)));
+			return;
 		}
+		const authError = handleAdminAuthFailure(res);
+		if (authError) setError(authError);
+		else setError(`Could not update flavor request (${res.status}).`);
 	}
 
 	if (loading) {
@@ -77,7 +89,13 @@ export default function AdminFlavorRequestsPage() {
 				<em>you</em> have contacted the customer — the site does not send automatic emails for these yet.
 			</p>
 
-			{requests.length === 0 ? (
+			{error && (
+				<p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">
+					{error}
+				</p>
+			)}
+
+			{requests.length === 0 && !error ? (
 				<p className="text-sage">No flavor requests yet.</p>
 			) : (
 				<div className="flex flex-col gap-5">

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import {
 	OrdersNavIcon,
 	SettingsNavIcon,
 } from "@/components/icons/navIcons";
+import { LogoutButton } from "@/components/admin/LogoutButton";
 
 /**
  * Admin layout: provides bakery-themed navigation for all admin pages.
@@ -47,12 +48,15 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
 							</Link>
 						</div>
 					</div>
-					<Link
-						href="/"
-						className="text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
-					>
-						← Back to site
-					</Link>
+					<div className="flex items-center gap-4">
+						<LogoutButton />
+						<Link
+							href="/"
+							className="text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
+						>
+							← Back to site
+						</Link>
+					</div>
 				</div>
 			</nav>
 			{children}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,34 +1,85 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
 
 export default function AdminLogin() {
-	const [key, setKey] = useState("");
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		if (new URLSearchParams(window.location.search).get("error") === "forbidden") {
+			setError("This account is not authorized for admin access.");
+		}
+	}, []);
+
+	async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		setError(null);
+		setLoading(true);
+
+		const supabase = createClient();
+		const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+		if (signInError) {
+			setError("Invalid email or password.");
+			setLoading(false);
+			return;
+		}
+
+		const { data, error: claimsError } = await supabase.auth.getClaims();
+		const appMetadata = data?.claims?.app_metadata;
+		const isAdmin =
+			!claimsError &&
+			typeof appMetadata === "object" &&
+			appMetadata !== null &&
+			(appMetadata as { role?: unknown }).role === "admin";
+
+		if (!isAdmin) {
+			await supabase.auth.signOut();
+			setError("This account is not authorized for admin access.");
+			setLoading(false);
+			return;
+		}
+
+		window.location.assign("/admin/orders");
+	}
+
 	return (
 		<main className="mx-auto max-w-md px-4 py-8">
 			<div className="card-warm p-6 sm:p-8">
 				<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Admin Login</h1>
-				<p className="mb-4 text-sm text-sage">Enter admin key to continue</p>
-				<form
-					onSubmit={(e) => {
-						e.preventDefault();
-						sessionStorage.setItem("admin_key", key.trim());
-						window.location.href = "/admin/orders";
-					}}
-					className="grid gap-4"
-				>
+				<p className="mb-4 text-sm text-sage">Sign in with your bakery admin account</p>
+				{error && (
+					<p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-sm text-berry" role="alert">
+						{error}
+					</p>
+				)}
+				<form onSubmit={handleSubmit} className="grid gap-4">
 					<label>
-						<span className="sr-only">Admin key</span>
+						<span className="mb-1.5 block text-sm font-medium text-cocoa">Email</span>
 						<input
-							type="password"
-							value={key}
-							onChange={(e) => setKey(e.target.value)}
-							placeholder="Admin key"
+							type="email"
+							value={email}
+							onChange={(event) => setEmail(event.target.value)}
+							autoComplete="email"
+							required
 							className="input-base"
-							autoComplete="current-password"
 						/>
 					</label>
-					<button type="submit" className="btn-primary">
-						Continue
+					<label>
+						<span className="mb-1.5 block text-sm font-medium text-cocoa">Password</span>
+						<input
+							type="password"
+							value={password}
+							onChange={(event) => setPassword(event.target.value)}
+							autoComplete="current-password"
+							required
+							className="input-base"
+						/>
+					</label>
+					<button type="submit" disabled={loading} className="btn-primary">
+						{loading ? "Signing in..." : "Sign in"}
 					</button>
 				</form>
 			</div>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { handleAdminAuthFailure } from "@/lib/adminResponse";
 import type { AdminOrderRecord, OrderStatus } from "@/lib/orderTypes";
 import {
 	getAllowedNextStatuses,
@@ -21,14 +22,10 @@ export default function AdminOrders() {
 
 	async function fetchList() {
 		setError(null);
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		const res = await fetch("/api/admin/list", { headers: { "x-admin-key": key } });
+		const res = await fetch("/api/admin/list");
 		if (!res.ok) {
-			if (res.status === 401) {
-				setError("Session expired. Please log in again.");
-				window.location.href = "/admin/login";
-				return;
-			}
+			const authError = handleAdminAuthFailure(res);
+			if (authError) return setError(authError);
 			const body = await res.json().catch(() => ({}));
 			setError((body as { error?: string }).error ?? `Failed to load orders (${res.status})`);
 			return;
@@ -43,13 +40,14 @@ export default function AdminOrders() {
 
 	async function setStatus(id: string, status: OrderStatus) {
 		setError(null);
-		const key = sessionStorage.getItem("admin_key") ?? "";
 		const res = await fetch(`/api/orders/${id}/status`, {
 			method: "POST",
-			headers: { "Content-Type": "application/json", "x-admin-key": key },
+			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ status }),
 		});
 		if (!res.ok) {
+			const authError = handleAdminAuthFailure(res);
+			if (authError) return setError(authError);
 			const body = await res.json().catch(() => ({}));
 			setError(
 				(body as { error?: string }).error ??

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function AdminPage() {
-	redirect("/admin/login");
+	redirect("/admin/orders");
 }

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,19 +1,8 @@
-"use client";
-
-import { useEffect } from "react";
-
 /**
  * Placeholder for shop-wide configuration (payment display, email templates, notifications, etc.).
  * Forms and persistence will be added after requirements are finalized with the client.
  */
 export default function AdminSettingsPage() {
-	useEffect(() => {
-		const key = sessionStorage.getItem("admin_key") ?? "";
-		if (!key) {
-			window.location.href = "/admin/login";
-		}
-	}, []);
-
 	return (
 		<main className="mx-auto max-w-4xl px-4 py-6">
 			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Settings</h1>

--- a/app/api/admin/flavor-requests/route.ts
+++ b/app/api/admin/flavor-requests/route.ts
@@ -1,16 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 
-function requireAdmin(req: NextRequest): NextResponse | null {
-	const key = (req.headers.get("x-admin-key") ?? "").trim();
-	const expectedKey = (process.env.ADMIN_KEY ?? "").trim();
-	if (!expectedKey || key !== expectedKey) return new NextResponse("Unauthorized", { status: 401 });
-	return null;
-}
-
-export async function GET(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+export async function GET() {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const { data, error } = await supabaseAdmin
 		.from("flavor_requests")
@@ -22,8 +16,8 @@ export async function GET(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const body = await req.json();
 	const { id, status } = body;

--- a/app/api/admin/inventory/bulk/route.ts
+++ b/app/api/admin/inventory/bulk/route.ts
@@ -13,7 +13,7 @@ export const dynamic = "force-dynamic";
 /**
  * POST /api/admin/inventory/bulk
  *
- * Upserts many slots from CSV or JSON (requires x-admin-key).
+ * Upserts many slots from CSV or JSON (requires an admin session).
  *
  * **CSV:** `Content-Type: text/csv` or `text/plain` — body is CSV text
  * (columns: item_id, period_type, period_start, quantity_available; optional quantity_sold column ignored).
@@ -22,8 +22,8 @@ export const dynamic = "force-dynamic";
  * with the same fields as CSV rows.
  */
 export async function POST(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const type = (req.headers.get("content-type") ?? "").toLowerCase();
 	let rowsResult: BulkRowsParseResult;

--- a/app/api/admin/inventory/export/route.ts
+++ b/app/api/admin/inventory/export/route.ts
@@ -8,11 +8,11 @@ export const dynamic = "force-dynamic";
 
 /**
  * GET /api/admin/inventory/export?format=csv|json
- * Download current inventory_slots for bulk editing (requires x-admin-key).
+ * Download current inventory_slots for bulk editing (requires an admin session).
  */
 export async function GET(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const format = (req.nextUrl.searchParams.get("format") ?? "csv").toLowerCase();
 

--- a/app/api/admin/inventory/route.ts
+++ b/app/api/admin/inventory/route.ts
@@ -3,9 +3,9 @@ import { requireAdmin } from "@/lib/adminAuth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { upsertInventorySlot } from "@/lib/inventoryUpsert";
 
-export async function GET(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+export async function GET() {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const { data, error } = await supabaseAdmin
 		.from("inventory_slots")
@@ -17,8 +17,8 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-	const err = requireAdmin(req);
-	if (err) return err;
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const body = await req.json();
 	const { item_id, period_type, period_start, quantity_available } = body;

--- a/app/api/admin/list/route.test.ts
+++ b/app/api/admin/list/route.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockFrom, mockSelect } = vi.hoisted(() => ({
+const { mockFrom, mockRequireAdmin, mockSelect } = vi.hoisted(() => ({
 	mockFrom: vi.fn(),
+	mockRequireAdmin: vi.fn(),
 	mockSelect: vi.fn(),
 }));
 
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
 vi.mock("@/lib/supabaseAdmin", () => ({
 	getSupabaseAdmin: () => ({ from: mockFrom }),
 }));
@@ -13,15 +15,24 @@ vi.mock("@/lib/supabaseAdmin", () => ({
 import { GET } from "./route";
 
 describe("GET /api/admin/list", () => {
-	const previousAdminKey = process.env.ADMIN_KEY;
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		process.env.ADMIN_KEY = "test-admin-key";
+		mockRequireAdmin.mockResolvedValue({
+			authorized: true,
+			admin: { id: "admin-1", email: "owner@example.com" },
+		});
 	});
 
-	afterEach(() => {
-		process.env.ADMIN_KEY = previousAdminKey;
+	it("does not query the privileged database when authentication fails", async () => {
+		mockRequireAdmin.mockResolvedValue({
+			authorized: false,
+			response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+		});
+
+		const response = await GET(new NextRequest("http://localhost/api/admin/list"));
+
+		expect(response.status).toBe(401);
+		expect(mockFrom).not.toHaveBeenCalled();
 	});
 
 	it("keeps customer details and provides the tracking token to authenticated admins", async () => {
@@ -48,9 +59,7 @@ describe("GET /api/admin/list", () => {
 		mockSelect.mockReturnValue(query);
 		mockFrom.mockReturnValue({ select: mockSelect });
 
-		const response = await GET(new NextRequest("http://localhost/api/admin/list", {
-			headers: { "x-admin-key": "test-admin-key" },
-		}));
+		const response = await GET(new NextRequest("http://localhost/api/admin/list"));
 		const body = await response.json();
 
 		expect(response.status).toBe(200);

--- a/app/api/admin/list/route.ts
+++ b/app/api/admin/list/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import type { AdminOrderRecord, OrderRecord } from "@/lib/orderTypes";
 
@@ -8,18 +9,8 @@ import type { AdminOrderRecord, OrderRecord } from "@/lib/orderTypes";
  * merged with payload (customer, items, totals).
  */
 export async function GET(req: NextRequest) {
-	const adminKey = req.headers.get("x-admin-key")?.trim() ?? "";
-	const expectedKey = (process.env.ADMIN_KEY ?? "").trim();
-
-	if (!expectedKey) {
-		return NextResponse.json(
-			{ error: "ADMIN_KEY not configured. Add it to .env.local" },
-			{ status: 500 }
-		);
-	}
-	if (adminKey !== expectedKey) {
-		return new NextResponse("Unauthorized", { status: 401 });
-	}
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const supabase = getSupabaseAdmin();
 	const statusFilter = req.nextUrl.searchParams.get("status") ?? undefined;

--- a/app/api/orders/[id]/status/route.test.ts
+++ b/app/api/orders/[id]/status/route.test.ts
@@ -1,13 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockEqForSelect, mockEqForUpdate, mockFrom, mockUpdate } = vi.hoisted(() => ({
+const { mockEqForSelect, mockEqForUpdate, mockFrom, mockRequireAdmin, mockUpdate } = vi.hoisted(() => ({
 	mockEqForSelect: vi.fn(),
 	mockEqForUpdate: vi.fn(),
 	mockFrom: vi.fn(),
+	mockRequireAdmin: vi.fn(),
 	mockUpdate: vi.fn(),
 }));
 
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
 vi.mock("@/lib/supabaseAdmin", () => ({
 	getSupabaseAdmin: () => ({ from: mockFrom }),
 }));
@@ -16,11 +18,12 @@ vi.mock("@/lib/notify", () => ({ notifyStatusChange: vi.fn().mockResolvedValue(u
 import { POST } from "./route";
 
 describe("POST /api/orders/[id]/status", () => {
-	const previousAdminKey = process.env.ADMIN_KEY;
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		process.env.ADMIN_KEY = "test-admin-key";
+		mockRequireAdmin.mockResolvedValue({
+			authorized: true,
+			admin: { id: "admin-1", email: "owner@example.com" },
+		});
 		mockEqForSelect.mockReturnValue({
 			single: vi.fn().mockResolvedValue({
 				data: {
@@ -44,15 +47,11 @@ describe("POST /api/orders/[id]/status", () => {
 		});
 	});
 
-	afterEach(() => {
-		process.env.ADMIN_KEY = previousAdminKey;
-	});
-
 	it("continues updating status by internal order ID", async () => {
 		const response = await POST(
 			new NextRequest("http://localhost/api/orders/ord_internal/status", {
 				method: "POST",
-				headers: { "Content-Type": "application/json", "x-admin-key": "test-admin-key" },
+				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ status: "PAID" }),
 			}),
 			{ params: Promise.resolve({ id: "ord_internal" }) },

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import type { OrderRecord, OrderStatus } from "@/lib/orderTypes";
 import { notifyStatusChange } from "@/lib/notify";
@@ -8,11 +9,8 @@ export async function POST(
 	req: NextRequest,
 	context: { params: Promise<{ id: string }> }
 ) {
-	const adminKey = (req.headers.get("x-admin-key") ?? "").trim();
-	const expectedKey = (process.env.ADMIN_KEY ?? "").trim();
-	if (!expectedKey || adminKey !== expectedKey) {
-		return new NextResponse("Unauthorized", { status: 401 });
-	}
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
 
 	const { id } = await context.params;
 	const { status } = (await req.json()) as { status: OrderStatus };

--- a/app/auth/signout/route.test.ts
+++ b/app/auth/signout/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const authState = vi.hoisted(() => ({ signedIn: true }));
+const { mockSignOut } = vi.hoisted(() => ({
+	mockSignOut: vi.fn(async () => {
+		authState.signedIn = false;
+		return { error: null };
+	}),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(async () => ({
+		auth: {
+			signOut: mockSignOut,
+			getClaims: vi.fn(async () =>
+				authState.signedIn
+					? {
+						data: { claims: { sub: "admin-1", app_metadata: { role: "admin" } } },
+						error: null,
+					}
+					: { data: null, error: null }
+			),
+		},
+	})),
+}));
+
+import { requireAdmin } from "@/lib/adminAuth";
+import { POST } from "./route";
+
+describe("POST /auth/signout", () => {
+	beforeEach(() => {
+		authState.signedIn = true;
+		vi.clearAllMocks();
+	});
+
+	it("signs out, redirects to login, and leaves protected requests unauthorized", async () => {
+		expect((await requireAdmin()).authorized).toBe(true);
+
+		const response = await POST(new NextRequest("http://localhost/auth/signout", { method: "POST" }));
+
+		expect(mockSignOut).toHaveBeenCalledOnce();
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location")).toBe("http://localhost/admin/login");
+		const protectedResult = await requireAdmin();
+		expect(protectedResult.authorized).toBe(false);
+		if (!protectedResult.authorized) expect(protectedResult.response.status).toBe(401);
+	});
+});

--- a/app/auth/signout/route.ts
+++ b/app/auth/signout/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function POST(request: NextRequest) {
+	const supabase = await createClient();
+	await supabase.auth.signOut();
+
+	const response = NextResponse.redirect(new URL("/admin/login", request.url), 303);
+	response.headers.set("Cache-Control", "private, no-store");
+	return response;
+}

--- a/components/admin/LogoutButton.tsx
+++ b/components/admin/LogoutButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export function LogoutButton() {
+	const pathname = usePathname();
+	if (pathname === "/admin/login") return null;
+
+	return (
+		<form action="/auth/signout" method="post">
+			<button
+				type="submit"
+				className="text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
+			>
+				Logout
+			</button>
+		</form>
+	);
+}

--- a/lib/adminAuth.test.ts
+++ b/lib/adminAuth.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetClaims } = vi.hoisted(() => ({
+	mockGetClaims: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(async () => ({ auth: { getClaims: mockGetClaims } })),
+}));
+
+import { requireAdmin } from "./adminAuth";
+
+describe("requireAdmin", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns 401 for an anonymous request", async () => {
+		mockGetClaims.mockResolvedValue({ data: null, error: null });
+
+		const result = await requireAdmin();
+
+		expect(result.authorized).toBe(false);
+		if (!result.authorized) expect(result.response.status).toBe(401);
+	});
+
+	it("returns 401 for invalid or expired authentication", async () => {
+		mockGetClaims.mockResolvedValue({ data: null, error: new Error("JWT expired") });
+
+		const result = await requireAdmin();
+
+		expect(result.authorized).toBe(false);
+		if (!result.authorized) expect(result.response.status).toBe(401);
+	});
+
+	it("returns 403 for an authenticated non-admin", async () => {
+		mockGetClaims.mockResolvedValue({
+			data: { claims: { sub: "user-1", email: "staff@example.com", app_metadata: { role: "staff" } } },
+			error: null,
+		});
+
+		const result = await requireAdmin();
+
+		expect(result.authorized).toBe(false);
+		if (!result.authorized) expect(result.response.status).toBe(403);
+	});
+
+	it("returns the verified identity for an admin", async () => {
+		mockGetClaims.mockResolvedValue({
+			data: { claims: { sub: "admin-1", email: "owner@example.com", app_metadata: { role: "admin" } } },
+			error: null,
+		});
+
+		const result = await requireAdmin();
+
+		expect(result).toEqual({
+			authorized: true,
+			admin: { id: "admin-1", email: "owner@example.com" },
+		});
+	});
+});

--- a/lib/adminAuth.ts
+++ b/lib/adminAuth.ts
@@ -1,9 +1,45 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
 
-/** Returns 401 response if `x-admin-key` does not match `ADMIN_KEY`, else null. */
-export function requireAdmin(req: NextRequest): NextResponse | null {
-	const key = (req.headers.get("x-admin-key") ?? "").trim();
-	const expectedKey = (process.env.ADMIN_KEY ?? "").trim();
-	if (!expectedKey || key !== expectedKey) return new NextResponse("Unauthorized", { status: 401 });
-	return null;
+export type AdminIdentity = {
+	id: string;
+	email?: string;
+};
+
+export type AdminAuthorization =
+	| { authorized: true; admin: AdminIdentity }
+	| { authorized: false; response: NextResponse };
+
+/** Verifies the cookie-backed Supabase identity and explicit admin role. */
+export async function requireAdmin(): Promise<AdminAuthorization> {
+	const supabase = await createClient();
+	const { data, error } = await supabase.auth.getClaims();
+	const claims = data?.claims;
+
+	if (error || typeof claims?.sub !== "string") {
+		return {
+			authorized: false,
+			response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+		};
+	}
+
+	const appMetadata = claims.app_metadata;
+	if (
+		typeof appMetadata !== "object" ||
+		appMetadata === null ||
+		(appMetadata as { role?: unknown }).role !== "admin"
+	) {
+		return {
+			authorized: false,
+			response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+		};
+	}
+
+	return {
+		authorized: true,
+		admin: {
+			id: claims.sub,
+			email: typeof claims.email === "string" ? claims.email : undefined,
+		},
+	};
 }

--- a/lib/adminResponse.ts
+++ b/lib/adminResponse.ts
@@ -1,0 +1,10 @@
+export function handleAdminAuthFailure(response: Response): string | null {
+	if (response.status === 401) {
+		window.location.assign("/admin/login");
+		return "Your session has expired. Please log in again.";
+	}
+	if (response.status === 403) {
+		return "You are signed in, but this account is not authorized for admin access.";
+	}
+	return null;
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,7 @@
+import { createBrowserClient } from "@supabase/ssr";
+import { getPublicSupabaseConfig } from "@/lib/supabase/config";
+
+export function createClient() {
+	const { url, publishableKey } = getPublicSupabaseConfig();
+	return createBrowserClient(url, publishableKey);
+}

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,10 @@
+const placeholderUrl = "https://placeholder.supabase.co";
+const placeholderPublishableKey = "placeholder";
+
+export function getPublicSupabaseConfig() {
+	return {
+		url: process.env.NEXT_PUBLIC_SUPABASE_URL || placeholderUrl,
+		publishableKey:
+			process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || placeholderPublishableKey,
+	};
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,0 +1,62 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextRequest, NextResponse } from "next/server";
+import { getPublicSupabaseConfig } from "@/lib/supabase/config";
+
+function copySessionResponse(source: NextResponse, destination: NextResponse) {
+	source.cookies.getAll().forEach((cookie) => destination.cookies.set(cookie));
+	for (const name of ["cache-control", "expires", "pragma"]) {
+		const value = source.headers.get(name);
+		if (value) destination.headers.set(name, value);
+	}
+	return destination;
+}
+
+export async function updateSession(request: NextRequest) {
+	let response = NextResponse.next({ request });
+	const { url, publishableKey } = getPublicSupabaseConfig();
+	const supabase = createServerClient(
+		url,
+		publishableKey,
+		{
+			cookies: {
+				getAll() {
+					return request.cookies.getAll();
+				},
+				setAll(cookiesToSet, responseHeaders) {
+					cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+					response = NextResponse.next({ request });
+					cookiesToSet.forEach(({ name, value, options }) =>
+						response.cookies.set(name, value, options)
+					);
+					Object.entries(responseHeaders).forEach(([name, value]) =>
+						response.headers.set(name, value)
+					);
+				},
+			},
+		}
+	);
+
+	const { data, error } = await supabase.auth.getClaims();
+	if (request.nextUrl.pathname === "/admin/login") return response;
+
+	const claims = data?.claims;
+	if (error || typeof claims?.sub !== "string") {
+		return copySessionResponse(
+			response,
+			NextResponse.redirect(new URL("/admin/login", request.url))
+		);
+	}
+
+	const appMetadata = claims.app_metadata;
+	if (
+		typeof appMetadata !== "object" ||
+		appMetadata === null ||
+		(appMetadata as { role?: unknown }).role !== "admin"
+	) {
+		const loginUrl = new URL("/admin/login", request.url);
+		loginUrl.searchParams.set("error", "forbidden");
+		return copySessionResponse(response, NextResponse.redirect(loginUrl));
+	}
+
+	return response;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,29 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { getPublicSupabaseConfig } from "@/lib/supabase/config";
+
+export async function createClient() {
+	const cookieStore = await cookies();
+	const { url, publishableKey } = getPublicSupabaseConfig();
+
+	return createServerClient(
+		url,
+		publishableKey,
+		{
+			cookies: {
+				getAll() {
+					return cookieStore.getAll();
+				},
+				setAll(cookiesToSet) {
+					try {
+						cookiesToSet.forEach(({ name, value, options }) =>
+							cookieStore.set(name, value, options)
+						);
+					} catch {
+						// Server Components cannot write cookies. Middleware refreshes them.
+					}
+				},
+			},
+		}
+	);
+}

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetClaims } = vi.hoisted(() => ({
+	mockGetClaims: vi.fn(),
+}));
+
+vi.mock("@supabase/ssr", () => ({
+	createServerClient: vi.fn(() => ({ auth: { getClaims: mockGetClaims } })),
+}));
+
+import { middleware } from "./middleware";
+
+describe("admin middleware", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+		process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "publishable-test-key";
+	});
+
+	it("does not trap the public admin login page", async () => {
+		mockGetClaims.mockResolvedValue({ data: null, error: null });
+
+		const response = await middleware(new NextRequest("http://localhost/admin/login"));
+
+		expect(response.headers.get("location")).toBeNull();
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+	});
+
+	it("redirects an unauthenticated admin page request to login", async () => {
+		mockGetClaims.mockResolvedValue({ data: null, error: null });
+
+		const response = await middleware(new NextRequest("http://localhost/admin/orders"));
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe("http://localhost/admin/login");
+	});
+
+	it("redirects an authenticated non-admin", async () => {
+		mockGetClaims.mockResolvedValue({
+			data: { claims: { sub: "user-1", app_metadata: { role: "staff" } } },
+			error: null,
+		});
+
+		const response = await middleware(new NextRequest("http://localhost/admin/orders"));
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe("http://localhost/admin/login?error=forbidden");
+	});
+
+	it("allows an authenticated admin to proceed", async () => {
+		mockGetClaims.mockResolvedValue({
+			data: { claims: { sub: "admin-1", app_metadata: { role: "admin" } } },
+			error: null,
+		});
+
+		const response = await middleware(new NextRequest("http://localhost/admin/orders"));
+
+		expect(response.headers.get("location")).toBeNull();
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+	});
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+	return updateSession(request);
+}
+
+export const config = {
+	matcher: ["/admin/:path*"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "little-town-bakes",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.91.1",
+        "@supabase/ssr": "0.12.7",
+        "@supabase/supabase-js": "2.116.0",
         "next": "15.5.25",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -1288,83 +1289,107 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.91.1.tgz",
-      "integrity": "sha512-3gFGMPuif2BOuAHXLAGsoOlDa64PROct1v7G94pMnvUAhh75u6+vnx4MYz1wyoyDBN5lCkJPGQNg5+RIgqxnpA==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.116.0.tgz",
+      "integrity": "sha512-Cmosty12gyKGK9N3bQb+lMmuAFev5nmUzaR1AsmZHqKOAGzqX1VQzmp49CNPwOx/pw0H9Qqk4rs9yhwTlKpfDg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.91.1.tgz",
-      "integrity": "sha512-xKepd3HZ6K6rKibriehKggIegsoz+jjV67tikN51q/YQq3AlUAkjUMSnMrqs8t5LMlAi+a3dJU812acXanR0cw==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.116.0.tgz",
+      "integrity": "sha512-E+VOc2QDcni/fySqkBFiZhnoB3SGydEdZgFI6/dEAGAHx6yEhB46TN9qb2wXs+E+RSzOBV0R6dasiSlw4xlZAA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.91.1.tgz",
-      "integrity": "sha512-UKumTC6SGHd65G/5Gj0V58u+SkUyiH4zEJ8OP2eb06+Tqnges1E/3Tl7lyq2qbcMP8nEyH/0M7m2bYjrn++haw==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.116.0.tgz",
+      "integrity": "sha512-kGpVZTDHxFTJS3tu+rU0iTAZ+4U0bcLVjxwCk8f3gRhjw3qdCZjTBlgYvc4kGH2XccmAzbkKwXL/mrNHMGSc+A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.91.1.tgz",
-      "integrity": "sha512-Y4rifuvzekFgd2hUfiEvcMoh/JU3s1hmpWYS7tNGL2QHuFfWg8a4w/qg5qoSMVDvgGRz6G4L6yB1FaQRTplENQ==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.116.0.tgz",
+      "integrity": "sha512-MHAnlXxi2s6yiJsZsQMfs2B3RFxeVfQWxerqYhIMqcCQV/FuY3LIeouPEkXw/ah7wUWMLYwempF9MOCUScyddg==",
       "license": "MIT",
       "dependencies": {
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.7.tgz",
+      "integrity": "sha512-wiBtEie1KkRJi9RrZWY3R2imRhX1JY7qMyUCH2z9AUk15gQebNEplM+urbCKamdxaTJLXUU6LlpkJsaxhojCEg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.114.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.91.1.tgz",
-      "integrity": "sha512-hMJNT2tSleOrWwx4FmHTpihIA2PRDixAsWflECuQ4YDkeduBZGX5m2txnstMnteWW+H+mm+92WRRFLuidXqbfA==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.116.0.tgz",
+      "integrity": "sha512-6/3hR6vccBP6oGM5B6RfbwZcTCKmQOodd/ZWQdsw8yJsU5zO/a//oBL6yLnmgxcjnHSrelW8rsO7hL5DPybyUQ==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.91.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.91.1.tgz",
-      "integrity": "sha512-57Fb4s5nfLn5ed2a1rPtl+LI1Wbtms8MS4qcUa0w6luaStBlFhmSeD2TLBgJWdMIupWRF6iFTH4QTrO2+pG/ZQ==",
+      "version": "2.116.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.116.0.tgz",
+      "integrity": "sha512-YyWmKXt2NspV9iO8FPnlswUFJIRnrLd3oTCb+3ZyYRuKZtBH0xCUDgnUqoyA0fGUxpM/UhfwDjYf/dht/9bp7g==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.91.1",
-        "@supabase/functions-js": "2.91.1",
-        "@supabase/postgrest-js": "2.91.1",
-        "@supabase/realtime-js": "2.91.1",
-        "@supabase/storage-js": "2.91.1"
+        "@supabase/auth-js": "2.116.0",
+        "@supabase/functions-js": "2.116.0",
+        "@supabase/postgrest-js": "2.116.0",
+        "@supabase/realtime-js": "2.116.0",
+        "@supabase/storage-js": "2.116.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/helpers": {
@@ -1761,16 +1786,11 @@
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
       "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
-      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
-      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.9",
@@ -1790,15 +1810,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3077,6 +3088,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6856,6 +6880,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7512,27 +7537,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.91.1",
+    "@supabase/ssr": "0.12.7",
+    "@supabase/supabase-js": "2.116.0",
     "next": "15.5.25",
     "react": "19.1.0",
     "react-dom": "19.1.0"


### PR DESCRIPTION
## Summary
- replaces the shared admin key with Supabase Auth email/password login and cookie-backed SSR sessions
- verifies protected requests with auth.getClaims and requires app_metadata.role === "admin"
- protects admin navigation with Next.js 15 middleware while retaining API authorization as the security boundary
- removes legacy client headers and browser session storage, and adds supported logout
- documents admin provisioning, recovery, and required environment variables

References #5. This PR intentionally does not auto-close the issue.

## Verification
- npm test: 16 files, 82 tests passed
- npm run lint: passed with no warnings or errors
- npm run build: passed
- npm run test:smoke: passed
- git diff --check: passed
- legacy auth string grep: zero matches

## Deployment notes
- configure NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY in Vercel
- provision admins through a trusted Supabase administrative method and set app_metadata.role to admin
- SUPABASE_SERVICE_ROLE_KEY remains server-only
- Supabase JS 2.116.0 declares Node.js 22 or later; local Node 20 verification passed with a deprecation warning