### PR TITLE
[P0] Simplify inventory to current on-hand stock

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Run migrations in order:
 3. `20250313100000_atomic_reserve_inventory.sql` – orders table + atomic reserve (prevents overselling)
 4. `20260909030347_protect_public_order_tracking.sql` – separate public tracking tokens from internal order IDs
 5. `20260909040137_create_catalog.sql` – product/category catalog tables and initial seed data
+6. `20260909150000_current_product_inventory.sql` – replaces period slots with current on-hand stock and atomic cancellation restoration
 
 ## Menu
 
-PostgreSQL tables `categories` and `products` are the authoritative catalog. Set `products.is_archived` to move an item between the current menu and Past Flavors. Availability remains in `inventory_slots`; an active product with no remaining stock stays visible but cannot be added to the cart. Product images remain under `public/img/`, and `products.image` stores their public paths (for example, `/img/cakepop_chocolate.png`).
+PostgreSQL tables `categories` and `products` are the authoritative catalog. Set `products.is_archived` to move an item between the current menu and Past Flavors. `product_inventory` stores one current `quantity_on_hand` per product; an active product at zero stays visible but cannot be ordered. The migration intentionally resets all prelaunch period inventory to zero. Product images remain under `public/img/`, and `products.image` stores their public paths (for example, `/img/cakepop_chocolate.png`).
 
 ## About Page
 
@@ -62,4 +63,5 @@ The administrative client used for provisioning must remain in server-only tooli
 - `npm run build` – production build
 - `npm run start` – production server
 - `npm run test` – Vitest unit tests
+- `npm run test:db` – isolated PostgreSQL inventory transaction and concurrency tests (requires Docker)
 - `npm run lint` – ESLint

--- a/app/admin/availability/page.tsx
+++ b/app/admin/availability/page.tsx
@@ -1,388 +1,148 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { InventorySlot } from "@/lib/inventory";
-import { getWeekStart, getMonthStart } from "@/lib/inventory";
-import { stringifyWeekTemplateCsv } from "@/lib/inventoryBulk";
+import type { ProductInventory } from "@/lib/inventory";
+import { stringifyInventoryTemplateCsv } from "@/lib/inventoryBulk";
 import { handleAdminAuthFailure } from "@/lib/adminResponse";
 
-/**
- * Admin page for setting menu availability: how many of each product
- * can be ordered per week or month. Prevents overselling.
- */
+type MenuItem = { id: string; name: string };
+
 export default function AdminAvailabilityPage() {
-	const [slots, setSlots] = useState<InventorySlot[]>([]);
-	const [menuItems, setMenuItems] = useState<{ id: string; name: string }[]>([]);
+	const [inventory, setInventory] = useState<ProductInventory[]>([]);
+	const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
 	const [loading, setLoading] = useState(true);
-	const now = new Date();
-	const [form, setForm] = useState({
-		item_id: "",
-		period_type: "week" as "week" | "month",
-		period_start: getWeekStart(now),
-		quantity_available: 0,
-	});
+	const [form, setForm] = useState({ product_id: "", quantity_on_hand: 0 });
 	const [saving, setSaving] = useState(false);
-	const [bulkMessage, setBulkMessage] = useState<string | null>(null);
-	const [bulkError, setBulkError] = useState<string | null>(null);
-	const [bulkBusy, setBulkBusy] = useState(false);
-	const [pageError, setPageError] = useState<string | null>(null);
+	const [message, setMessage] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	async function loadInventory() {
+		const response = await fetch("/api/admin/inventory");
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? `Failed to load inventory (${response.status}).`);
+			return;
+		}
+		setInventory(await response.json());
+	}
 
 	useEffect(() => {
-		Promise.all([
-			fetch("/api/admin/inventory"),
-			fetch("/api/menu").then((r) => r.json()),
-		])
-			.then(async ([slotsResponse, menuData]) => {
-				if (!slotsResponse.ok) {
-					const authError = handleAdminAuthFailure(slotsResponse);
-					setPageError(authError ?? `Failed to load availability (${slotsResponse.status}).`);
+		Promise.all([fetch("/api/admin/inventory"), fetch("/api/menu")])
+			.then(async ([inventoryResponse, menuResponse]) => {
+				if (!inventoryResponse.ok) {
+					setError(handleAdminAuthFailure(inventoryResponse) ?? `Failed to load inventory (${inventoryResponse.status}).`);
 					return;
 				}
-				const slotsData = await slotsResponse.json();
-				setSlots(Array.isArray(slotsData) ? slotsData : []);
-				const items = (menuData?.items ?? []).map((i: { id: string; name: string }) => ({
-					id: i.id,
-					name: i.name,
-				}));
-				setMenuItems(items);
+				setInventory(await inventoryResponse.json());
+				const menu = await menuResponse.json();
+				setMenuItems([...(menu.items ?? []), ...(menu.archivedItems ?? [])]);
 			})
 			.finally(() => setLoading(false));
 	}, []);
 
 	function triggerDownload(blob: Blob, filename: string) {
 		const url = URL.createObjectURL(blob);
-		const a = document.createElement("a");
-		a.href = url;
-		a.download = filename;
-		a.click();
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = filename;
+		anchor.click();
 		URL.revokeObjectURL(url);
 	}
 
 	async function downloadExport(format: "csv" | "json") {
-		setBulkError(null);
-		setBulkMessage(null);
-		setBulkBusy(true);
-		try {
-			const res = await fetch(`/api/admin/inventory/export?format=${format}`);
-			if (!res.ok) {
-				const authError = handleAdminAuthFailure(res);
-				if (authError) {
-					setBulkError(authError);
-					return;
-				}
-				const err = await res.json().catch(() => ({}));
-				setBulkError((err as { error?: string }).error ?? `Download failed (${res.status})`);
-				return;
-			}
-			const blob = await res.blob();
-			const fromHeader = res.headers.get("Content-Disposition")?.match(/filename="([^"]+)"/)?.[1];
-			const fallback = `inventory-slots.${format === "csv" ? "csv" : "json"}`;
-			triggerDownload(blob, fromHeader ?? fallback);
-			setBulkMessage(`Downloaded ${format.toUpperCase()} — edit offline, then upload below.`);
-		} finally {
-			setBulkBusy(false);
+		const response = await fetch(`/api/admin/inventory/export?format=${format}`);
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? `Download failed (${response.status}).`);
+			return;
 		}
+		triggerDownload(await response.blob(), `inventory.${format}`);
 	}
 
-	function downloadWeekTemplate() {
-		setBulkError(null);
-		setBulkMessage(null);
-		const ws = getWeekStart(now);
-		const csv = stringifyWeekTemplateCsv(
-			menuItems.map((m) => ({ item_id: m.id, item_name: m.name })),
-			ws
+	function downloadTemplate() {
+		const csv = stringifyInventoryTemplateCsv(
+			menuItems.map((item) => ({ product_id: item.id, product_name: item.name }))
 		);
-		triggerDownload(
-			new Blob([csv], { type: "text/csv;charset=utf-8" }),
-			`availability-week-template-${ws}.csv`
-		);
-		setBulkMessage(
-			`Template uses this week’s start (${ws}). Set quantities in the last column, save as CSV, then upload.`
-		);
+		triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), "inventory-template.csv");
 	}
 
 	async function uploadBulkFile(file: File) {
-		setBulkError(null);
-		setBulkMessage(null);
-		setBulkBusy(true);
-		try {
-			const text = await file.text();
-			const isJson = file.name.toLowerCase().endsWith(".json");
-			const res = await fetch("/api/admin/inventory/bulk", {
-				method: "POST",
-				headers: {
-					"Content-Type": isJson ? "application/json" : "text/csv",
-				},
-				body: text,
-			});
-			const data = await res.json().catch(() => ({}));
-			if (!res.ok) {
-				const authError = handleAdminAuthFailure(res);
-				if (authError) {
-					setBulkError(authError);
-					return;
-				}
-				setBulkError((data as { error?: string }).error ?? `Upload failed (${res.status})`);
-				return;
-			}
-			const d = data as { created?: number; updated?: number; errors?: { index: number; message: string }[] };
-			const errs = d.errors ?? [];
-			const parts = [`${d.created ?? 0} created`, `${d.updated ?? 0} updated`];
-			setBulkMessage(parts.join(", ") + ".");
-			if (errs.length > 0) {
-				const preview = errs
-					.slice(0, 5)
-					.map((e) => `row ${e.index + 1}: ${e.message}`)
-					.join("; ");
-				setBulkError(
-					`${errs.length} row(s) failed (${preview}${errs.length > 5 ? "…" : ""}). Successful rows were still saved.`
-				);
-			}
-			const slotsRes = await fetch("/api/admin/inventory");
-			if (slotsRes.ok) {
-				const slotsData = await slotsRes.json();
-				setSlots(Array.isArray(slotsData) ? slotsData : []);
-			} else {
-				const authError = handleAdminAuthFailure(slotsRes);
-				if (authError) setBulkError(authError);
-			}
-		} finally {
-			setBulkBusy(false);
+		setError(null);
+		const isJson = file.name.toLowerCase().endsWith(".json");
+		const response = await fetch("/api/admin/inventory/bulk", {
+			method: "POST",
+			headers: { "Content-Type": isJson ? "application/json" : "text/csv" },
+			body: await file.text(),
+		});
+		const result = await response.json().catch(() => ({}));
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Upload failed (${response.status}).`);
+			return;
 		}
+		setMessage(`${result.updated ?? 0} updated${result.errors?.length ? `; ${result.errors.length} failed` : ""}.`);
+		await loadInventory();
 	}
 
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		setPageError(null);
+	async function handleSubmit(event: React.FormEvent) {
+		event.preventDefault();
 		setSaving(true);
-		const res = await fetch("/api/admin/inventory", {
+		setError(null);
+		const response = await fetch("/api/admin/inventory", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(form),
 		});
 		setSaving(false);
-		if (res.ok) {
-			const data = await res.json();
-			setSlots((prev) => {
-				const idx = prev.findIndex(
-					(s) =>
-						s.item_id === data.item_id &&
-						s.period_type === data.period_type &&
-						s.period_start === data.period_start
-				);
-				if (idx >= 0) {
-					const next = [...prev];
-					next[idx] = data;
-					return next;
-				}
-				return [data, ...prev];
-			});
-			setForm({
-				item_id: "",
-				period_type: "week",
-				period_start: getWeekStart(now),
-				quantity_available: 0,
-			});
+		if (!response.ok) {
+			const result = await response.json().catch(() => ({}));
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Could not save inventory (${response.status}).`);
 			return;
 		}
-		const authError = handleAdminAuthFailure(res);
-		setPageError(authError ?? `Could not save availability (${res.status}).`);
+		const saved = await response.json();
+		setInventory((current) => current.map((row) => row.product_id === saved.product_id ? saved : row));
+		setMessage("Inventory saved.");
 	}
 
-	const weekStart = getWeekStart(now);
-	const monthStart = getMonthStart(now);
-
-	if (loading) {
-		return (
-			<main className="mx-auto max-w-5xl px-4 py-6">
-				<p className="text-sage">Loading...</p>
-			</main>
-		);
-	}
+	if (loading) return <main className="mx-auto max-w-5xl px-4 py-6"><p className="text-sage">Loading...</p></main>;
 
 	return (
 		<main className="mx-auto max-w-5xl px-4 py-6">
-			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Menu availability</h1>
-			<p className="mb-6 text-sm text-sage">
-				Set how many of each product customers can order per week or month. This prevents overselling.
-			</p>
-
-			{pageError && (
-				<p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">
-					{pageError}
-				</p>
-			)}
+			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Inventory</h1>
+			<p className="mb-6 text-sm text-sage">Set the exact quantity currently on hand for each product.</p>
+			{error && <p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">{error}</p>}
+			{message && <p className="mb-4 text-sm text-success" role="status">{message}</p>}
 
 			<section className="card-warm mb-8 p-6 sm:p-8">
-				<h2 className="mb-2 font-display text-lg font-semibold text-cocoa">Bulk edit (CSV or JSON)</h2>
-				<p className="mb-4 text-sm text-sage">
-					Download current limits or a blank week template, edit in Excel or another editor, then upload. The CSV
-					from &quot;Download CSV&quot; includes sold counts for reference; only the limit column is applied on
-					import.
-				</p>
-				<div className="mb-4 flex flex-wrap gap-2">
-					<button
-						type="button"
-						disabled={bulkBusy}
-						onClick={() => downloadExport("csv")}
-						className="btn-secondary"
-					>
-						Download CSV
-					</button>
-					<button
-						type="button"
-						disabled={bulkBusy}
-						onClick={() => downloadExport("json")}
-						className="btn-secondary"
-					>
-						Download JSON
-					</button>
-					<button
-						type="button"
-						disabled={bulkBusy || menuItems.length === 0}
-						onClick={downloadWeekTemplate}
-						className="btn-secondary"
-					>
-						Week template (all items)
-					</button>
-				</div>
-				<label className="block">
-					<span className="mb-1.5 block text-sm font-medium text-cocoa">Upload CSV or JSON</span>
-					<input
-						type="file"
-						accept=".csv,.json,text/csv,application/json"
-						disabled={bulkBusy}
-						onChange={(e) => {
-							const f = e.target.files?.[0];
-							e.target.value = "";
-							if (f) void uploadBulkFile(f);
-						}}
-						className="input-base max-w-md cursor-pointer text-sm file:mr-3 file:rounded file:border-0 file:bg-honey file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-white hover:file:bg-caramel"
-					/>
-				</label>
-				{bulkMessage && (
-					<p className="mt-3 text-sm text-success" role="status">
-						{bulkMessage}
-					</p>
-				)}
-				{bulkError && (
-					<p className="mt-3 text-sm text-berry" role="alert">
-						{bulkError}
-					</p>
-				)}
-			</section>
-
-			<section className="card-warm mb-8 p-6 sm:p-8">
-				<h2 className="mb-4 font-display text-lg font-semibold text-cocoa">Add or update</h2>
+				<h2 className="mb-4 font-display text-lg font-semibold text-cocoa">Update on-hand stock</h2>
 				<form onSubmit={handleSubmit} className="grid max-w-md gap-4">
-					<label>
-						<div className="mb-1.5 text-sm font-medium text-cocoa">Menu item</div>
-						<select
-							value={form.item_id}
-							onChange={(e) => setForm((f) => ({ ...f, item_id: e.target.value }))}
-							required
-							className="input-base"
-						>
-							<option value="">Select item</option>
-							{menuItems.map((i) => (
-								<option key={i.id} value={i.id}>
-									{i.name}
-								</option>
-							))}
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">Product</span>
+						<select value={form.product_id} onChange={(event) => setForm((current) => ({ ...current, product_id: event.target.value }))} required className="input-base">
+							<option value="">Select product</option>
+							{menuItems.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
 						</select>
 					</label>
-					<label>
-						<div className="mb-1.5 text-sm font-medium text-cocoa">Period type</div>
-						<select
-							value={form.period_type}
-							onChange={(e) =>
-								setForm((f) => ({
-									...f,
-									period_type: e.target.value as "week" | "month",
-									period_start: e.target.value === "week" ? weekStart : monthStart,
-								}))
-							}
-							className="input-base"
-						>
-							<option value="week">Week</option>
-							<option value="month">Month</option>
-						</select>
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">On hand</span>
+						<input type="number" min={0} step={1} value={form.quantity_on_hand} onChange={(event) => setForm((current) => ({ ...current, quantity_on_hand: Number(event.target.value) }))} required className="input-base" />
 					</label>
-					<label>
-						<div className="mb-1.5 text-sm font-medium text-cocoa">Period start (YYYY-MM-DD)</div>
-						<input
-							type="date"
-							value={form.period_start}
-							onChange={(e) => setForm((f) => ({ ...f, period_start: e.target.value }))}
-							required
-							className="input-base"
-						/>
-					</label>
-					<label>
-						<div className="mb-1.5 text-sm font-medium text-cocoa">Quantity available</div>
-						<input
-							type="number"
-							min={0}
-							value={form.quantity_available || ""}
-							onChange={(e) =>
-								setForm((f) => ({ ...f, quantity_available: Number(e.target.value) || 0 }))
-							}
-							required
-							className="input-base"
-						/>
-					</label>
-					<button
-						type="submit"
-						disabled={saving || !form.item_id || !form.period_start}
-						className="btn-primary"
-					>
-						{saving ? "Saving..." : "Save"}
-					</button>
+					<button type="submit" disabled={saving || !form.product_id} className="btn-primary">{saving ? "Saving..." : "Save"}</button>
 				</form>
 			</section>
 
+			<section className="card-warm mb-8 p-6 sm:p-8">
+				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Bulk edit</h2>
+				<div className="mb-4 flex flex-wrap gap-2">
+					<button type="button" onClick={() => void downloadExport("csv")} className="btn-secondary">Download CSV</button>
+					<button type="button" onClick={() => void downloadExport("json")} className="btn-secondary">Download JSON</button>
+					<button type="button" onClick={downloadTemplate} className="btn-secondary">Product template</button>
+				</div>
+				<input type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => { const file = event.target.files?.[0]; event.target.value = ""; if (file) void uploadBulkFile(file); }} className="input-base max-w-md" />
+			</section>
+
 			<section>
-				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Current availability</h2>
-				{slots.length === 0 ? (
-					<p className="text-sage">No availability set yet. Add one above to start selling.</p>
-				) : (
-					<div className="overflow-x-auto rounded-card border border-crust bg-wheat/50 shadow-soft">
-						<table className="w-full min-w-[520px] border-collapse text-left text-sm">
-							<thead>
-								<tr className="border-b border-crust bg-cream/90">
-									<th scope="col" className="px-4 py-3 font-display font-semibold text-cocoa">
-										Item
-									</th>
-									<th scope="col" className="px-4 py-3 font-display font-semibold text-cocoa">
-										Period
-									</th>
-									<th scope="col" className="px-4 py-3 font-display font-semibold text-cocoa">
-										Starts
-									</th>
-									<th scope="col" className="px-4 py-3 font-display font-semibold text-cocoa">
-										Sold / limit
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								{slots.map((s) => (
-									<tr key={s.id} className="border-b border-crust/80 last:border-0 hover:bg-cream/40">
-										<td className="px-4 py-3 font-medium text-cocoa">
-											{menuItems.find((m) => m.id === s.item_id)?.name ?? s.item_id}
-										</td>
-										<td className="px-4 py-3 capitalize text-sage">{s.period_type}</td>
-										<td className="px-4 py-3 tabular-nums text-cocoa">{s.period_start}</td>
-										<td className="px-4 py-3 tabular-nums text-cocoa">
-											<span className="font-medium text-caramel">{s.quantity_sold}</span>
-											<span className="text-sage"> / </span>
-											{s.quantity_available}
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				)}
+				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Current stock</h2>
+				<div className="overflow-x-auto rounded-card border border-crust bg-wheat/50 shadow-soft">
+					<table className="w-full border-collapse text-left text-sm"><thead><tr className="border-b border-crust bg-cream/90"><th className="px-4 py-3">Product</th><th className="px-4 py-3">On hand</th></tr></thead>
+						<tbody>{inventory.map((row) => <tr key={row.product_id} className="border-b border-crust/80 last:border-0"><td className="px-4 py-3">{menuItems.find((item) => item.id === row.product_id)?.name ?? row.product_id}</td><td className="px-4 py-3 tabular-nums">{row.quantity_on_hand}</td></tr>)}</tbody>
+					</table>
+				</div>
 			</section>
 		</main>
 	);

--- a/app/api/admin/inventory/bulk/route.ts
+++ b/app/api/admin/inventory/bulk/route.ts
@@ -6,17 +6,17 @@ import {
 	validateBulkRow,
 	type BulkRowsParseResult,
 } from "@/lib/inventoryBulk";
-import { upsertInventorySlot } from "@/lib/inventoryUpsert";
+import { setProductInventory } from "@/lib/inventoryUpsert";
 
 export const dynamic = "force-dynamic";
 
 /**
  * POST /api/admin/inventory/bulk
  *
- * Upserts many slots from CSV or JSON (requires an admin session).
+ * Sets current on-hand quantities from CSV or JSON (requires an admin session).
  *
  * **CSV:** `Content-Type: text/csv` or `text/plain` — body is CSV text
- * (columns: item_id, period_type, period_start, quantity_available; optional quantity_sold column ignored).
+ * (columns: product_id, quantity_on_hand).
  *
  * **JSON:** `Content-Type: application/json` — either `[{...}, ...]` or `{ "rows": [...] }`
  * with the same fields as CSV rows.
@@ -47,7 +47,6 @@ export async function POST(req: NextRequest) {
 	}
 
 	const errors: { index: number; message: string }[] = [];
-	let created = 0;
 	let updated = 0;
 
 	for (let i = 0; i < rowsResult.rows.length; i++) {
@@ -57,17 +56,15 @@ export async function POST(req: NextRequest) {
 			errors.push({ index: v.index, message: v.message });
 			continue;
 		}
-		const up = await upsertInventorySlot(v.row);
+		const up = await setProductInventory(v.row);
 		if (!up.ok) {
 			errors.push({ index: i, message: up.error });
 			continue;
 		}
-		if (up.created) created++;
-		else updated++;
+		updated++;
 	}
 
 	return NextResponse.json({
-		created,
 		updated,
 		errors,
 		processed: rowsResult.rows.length,

--- a/app/api/admin/inventory/export/route.ts
+++ b/app/api/admin/inventory/export/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/adminAuth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { stringifyInventoryCsv } from "@/lib/inventoryBulk";
-import type { InventorySlot } from "@/lib/inventory";
+import type { ProductInventory } from "@/lib/inventory";
 
 export const dynamic = "force-dynamic";
 
 /**
  * GET /api/admin/inventory/export?format=csv|json
- * Download current inventory_slots for bulk editing (requires an admin session).
+ * Download current on-hand inventory for bulk editing (requires an admin session).
  */
 export async function GET(req: NextRequest) {
 	const authorization = await requireAdmin();
@@ -17,21 +17,21 @@ export async function GET(req: NextRequest) {
 	const format = (req.nextUrl.searchParams.get("format") ?? "csv").toLowerCase();
 
 	const { data, error } = await supabaseAdmin
-		.from("inventory_slots")
+		.from("product_inventory")
 		.select("*")
-		.order("period_start", { ascending: false });
+		.order("product_id", { ascending: true });
 
 	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
 
-	const slots = (data ?? []) as InventorySlot[];
+	const inventory = (data ?? []) as ProductInventory[];
 	const stamp = new Date().toISOString().slice(0, 10);
 
 	if (format === "json") {
-		const body = JSON.stringify(slots, null, 2);
+		const body = JSON.stringify(inventory, null, 2);
 		return new NextResponse(body, {
 			headers: {
 				"Content-Type": "application/json; charset=utf-8",
-				"Content-Disposition": `attachment; filename="inventory-slots-${stamp}.json"`,
+				"Content-Disposition": `attachment; filename="inventory-${stamp}.json"`,
 			},
 		});
 	}
@@ -40,11 +40,11 @@ export async function GET(req: NextRequest) {
 		return NextResponse.json({ error: "format must be csv or json" }, { status: 400 });
 	}
 
-	const csv = stringifyInventoryCsv(slots);
+	const csv = stringifyInventoryCsv(inventory);
 	return new NextResponse(csv, {
 		headers: {
 			"Content-Type": "text/csv; charset=utf-8",
-			"Content-Disposition": `attachment; filename="inventory-slots-${stamp}.csv"`,
+			"Content-Disposition": `attachment; filename="inventory-${stamp}.csv"`,
 		},
 	});
 }

--- a/app/api/admin/inventory/route.test.ts
+++ b/app/api/admin/inventory/route.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockSetProductInventory } = vi.hoisted(() => ({
+	mockRequireAdmin: vi.fn(),
+	mockSetProductInventory: vi.fn(),
+}));
+
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/inventoryUpsert", () => ({ setProductInventory: mockSetProductInventory }));
+vi.mock("@/lib/supabaseAdmin", () => ({ supabaseAdmin: {} }));
+
+import { POST } from "./route";
+
+function request(body: unknown) {
+	return new NextRequest("http://localhost/api/admin/inventory", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("POST /api/admin/inventory", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireAdmin.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+		mockSetProductInventory.mockImplementation(async (input) => ({ ok: true, data: input }));
+	});
+
+	it("sets an absolute current on-hand quantity", async () => {
+		const response = await POST(request({ product_id: "cake", quantity_on_hand: 18 }));
+
+		expect(response.status).toBe(200);
+		expect(mockSetProductInventory).toHaveBeenCalledWith({
+			product_id: "cake",
+			quantity_on_hand: 18,
+		});
+	});
+
+	it.each([-1, 1.5, Number.NaN])("rejects invalid quantity %s", async (quantity) => {
+		const response = await POST(request({ product_id: "cake", quantity_on_hand: quantity }));
+
+		expect(response.status).toBe(400);
+		expect(mockSetProductInventory).not.toHaveBeenCalled();
+	});
+});

--- a/app/api/admin/inventory/route.ts
+++ b/app/api/admin/inventory/route.ts
@@ -1,16 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/adminAuth";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { upsertInventorySlot } from "@/lib/inventoryUpsert";
+import { setProductInventory } from "@/lib/inventoryUpsert";
 
 export async function GET() {
 	const authorization = await requireAdmin();
 	if (!authorization.authorized) return authorization.response;
 
 	const { data, error } = await supabaseAdmin
-		.from("inventory_slots")
+		.from("product_inventory")
 		.select("*")
-		.order("period_start", { ascending: false });
+		.order("product_id", { ascending: true });
 
 	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
 	return NextResponse.json(data ?? []);
@@ -21,23 +21,21 @@ export async function POST(req: NextRequest) {
 	if (!authorization.authorized) return authorization.response;
 
 	const body = await req.json();
-	const { item_id, period_type, period_start, quantity_available } = body;
+	const { product_id, quantity_on_hand } = body;
 
-	if (!item_id || !period_type || !period_start || typeof quantity_available !== "number") {
+	if (typeof product_id !== "string" || !product_id.trim()) {
+		return NextResponse.json({ error: "product_id is required" }, { status: 400 });
+	}
+	if (!Number.isSafeInteger(quantity_on_hand) || quantity_on_hand < 0 || quantity_on_hand > 2147483647) {
 		return NextResponse.json(
-			{ error: "item_id, period_type, period_start, quantity_available required" },
+			{ error: "quantity_on_hand must be a non-negative integer" },
 			{ status: 400 }
 		);
 	}
-	if (!["week", "month"].includes(period_type)) {
-		return NextResponse.json({ error: "period_type must be week or month" }, { status: 400 });
-	}
 
-	const result = await upsertInventorySlot({
-		item_id,
-		period_type,
-		period_start,
-		quantity_available,
+	const result = await setProductInventory({
+		product_id: product_id.trim(),
+		quantity_on_hand,
 	});
 	if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
 	return NextResponse.json(result.data);

--- a/app/api/menu/route.test.ts
+++ b/app/api/menu/route.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getWeekStart } from "@/lib/inventory";
 
 const { mockFrom } = vi.hoisted(() => ({
 	mockFrom: vi.fn(),
@@ -78,7 +77,7 @@ function setDatabaseResults({
 		if (table === "products") {
 			return { select: vi.fn().mockResolvedValue(queryResult(productRows, productError)) };
 		}
-		if (table === "inventory_slots") {
+		if (table === "product_inventory") {
 			return { select: vi.fn().mockResolvedValue(queryResult(inventoryRows)) };
 		}
 		throw new Error(`Unexpected table ${table}`);
@@ -93,14 +92,7 @@ describe("GET /api/menu", () => {
 
 	it("maps active database products into the existing API contract", async () => {
 		setDatabaseResults({
-			inventoryRows: [{
-				id: "slot-1",
-				item_id: "chocolate-cake",
-				period_type: "week",
-				period_start: getWeekStart(new Date()),
-				quantity_available: 5,
-				quantity_sold: 1,
-			}],
+			inventoryRows: [{ product_id: "chocolate-cake", quantity_on_hand: 4 }],
 		});
 
 		const response = await GET();
@@ -134,14 +126,7 @@ describe("GET /api/menu", () => {
 
 	it("keeps a zero-stock active product visible but unavailable", async () => {
 		setDatabaseResults({
-			inventoryRows: [{
-				id: "slot-1",
-				item_id: "apple-cake",
-				period_type: "week",
-				period_start: getWeekStart(new Date()),
-				quantity_available: 3,
-				quantity_sold: 3,
-			}],
+			inventoryRows: [{ product_id: "apple-cake", quantity_on_hand: 0 }],
 		});
 
 		const response = await GET();

--- a/app/api/menu/route.ts
+++ b/app/api/menu/route.ts
@@ -1,13 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
 import type { Category, Item } from "@/lib/menuCatalog";
-import {
-	getWeekStart,
-	getMonthStart,
-	getRemaining,
-	findRelevantSlot,
-	type InventorySlot,
-} from "@/lib/inventory";
+import { getQuantityOnHand, type ProductInventory } from "@/lib/inventory";
 
 type CategoryRow = {
 	id: string;
@@ -66,12 +60,12 @@ function mapProduct(row: ProductRow): Item {
 export async function GET() {
 	try {
 		const supabase = getSupabaseAdmin();
-		const [categoriesResult, productsResult, slotsResult] = await Promise.all([
+		const [categoriesResult, productsResult, inventoryResult] = await Promise.all([
 			supabase.from("categories").select("id, name, sort_order"),
 			supabase
 				.from("products")
 				.select("id, category_id, name, description, price_cents, image, max_per_order, is_archived, sort_order"),
-			supabase.from("inventory_slots").select("*"),
+			supabase.from("product_inventory").select("product_id, quantity_on_hand"),
 		]);
 
 		if (categoriesResult.error || productsResult.error) {
@@ -86,20 +80,12 @@ export async function GET() {
 		const catalogItems = ((productsResult.data ?? []) as ProductRow[])
 			.map(mapProduct)
 			.sort(compareCatalogEntries);
-		const inventorySlots = slotsResult.error ? [] : ((slotsResult.data ?? []) as InventorySlot[]);
-		const now = new Date();
-		const weekStart = getWeekStart(now);
-		const monthStart = getMonthStart(now);
-
-		const relevantSlots = inventorySlots.filter(
-			(slot) =>
-				(slot.period_type === "week" && slot.period_start === weekStart) ||
-				(slot.period_type === "month" && slot.period_start === monthStart)
-		);
+		const inventory = inventoryResult.error
+			? []
+			: ((inventoryResult.data ?? []) as ProductInventory[]);
 
 		const enrichedItems = catalogItems.map((item) => {
-			const slot = findRelevantSlot(relevantSlots, item.id, now);
-			const remaining = slot ? getRemaining(slot) : 0;
+			const remaining = getQuantityOnHand(inventory, item.id);
 			const available = remaining > 0;
 
 			return {

--- a/app/api/orders/[id]/status/route.test.ts
+++ b/app/api/orders/[id]/status/route.test.ts
@@ -1,17 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockEqForSelect, mockEqForUpdate, mockFrom, mockRequireAdmin, mockUpdate } = vi.hoisted(() => ({
+const { mockEqForSelect, mockEqForUpdate, mockExpectedStatusEq, mockFrom, mockMaybeSingleForUpdate, mockRequireAdmin, mockRpc, mockUpdate } = vi.hoisted(() => ({
 	mockEqForSelect: vi.fn(),
 	mockEqForUpdate: vi.fn(),
+	mockExpectedStatusEq: vi.fn(),
 	mockFrom: vi.fn(),
+	mockMaybeSingleForUpdate: vi.fn(),
 	mockRequireAdmin: vi.fn(),
+	mockRpc: vi.fn(),
 	mockUpdate: vi.fn(),
 }));
 
 vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
 vi.mock("@/lib/supabaseAdmin", () => ({
-	getSupabaseAdmin: () => ({ from: mockFrom }),
+	getSupabaseAdmin: () => ({ from: mockFrom, rpc: mockRpc }),
 }));
 vi.mock("@/lib/notify", () => ({ notifyStatusChange: vi.fn().mockResolvedValue(undefined) }));
 
@@ -27,6 +30,7 @@ describe("POST /api/orders/[id]/status", () => {
 		mockEqForSelect.mockReturnValue({
 			single: vi.fn().mockResolvedValue({
 				data: {
+					status: "AWAITING_PAYMENT",
 					payload: {
 						id: "ord_internal",
 						createdAt: "2026-09-08T20:00:00.000Z",
@@ -39,12 +43,38 @@ describe("POST /api/orders/[id]/status", () => {
 				error: null,
 			}),
 		});
-		mockEqForUpdate.mockResolvedValue({ error: null });
+		mockMaybeSingleForUpdate.mockResolvedValue({ data: { id: "ord_internal" }, error: null });
+		mockExpectedStatusEq.mockReturnValue({
+			select: vi.fn(() => ({
+				maybeSingle: mockMaybeSingleForUpdate,
+			})),
+		});
+		mockEqForUpdate.mockReturnValue({
+			eq: mockExpectedStatusEq,
+		});
+		mockRpc.mockResolvedValue({ data: { canceled: true, restored: true }, error: null });
 		mockUpdate.mockReturnValue({ eq: mockEqForUpdate });
 		mockFrom.mockReturnValue({
 			select: vi.fn(() => ({ eq: mockEqForSelect })),
 			update: mockUpdate,
 		});
+	});
+
+	it("cancels through the atomic restoration RPC", async () => {
+		const response = await POST(
+			new NextRequest("http://localhost/api/orders/ord_internal/status", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ status: "CANCELED" }),
+			}),
+			{ params: Promise.resolve({ id: "ord_internal" }) },
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockRpc).toHaveBeenCalledWith("cancel_order_and_restore_inventory", {
+			p_order_id: "ord_internal",
+		});
+		expect(mockUpdate).not.toHaveBeenCalled();
 	});
 
 	it("continues updating status by internal order ID", async () => {
@@ -60,6 +90,22 @@ describe("POST /api/orders/[id]/status", () => {
 		expect(response.status).toBe(200);
 		expect(mockEqForSelect).toHaveBeenCalledWith("id", "ord_internal");
 		expect(mockEqForUpdate).toHaveBeenCalledWith("id", "ord_internal");
+		expect(mockExpectedStatusEq).toHaveBeenCalledWith("status", "AWAITING_PAYMENT");
 		expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: "PAID" }));
+	});
+
+	it("does not overwrite a status changed by a concurrent request", async () => {
+		mockMaybeSingleForUpdate.mockResolvedValue({ data: null, error: null });
+
+		const response = await POST(
+			new NextRequest("http://localhost/api/orders/ord_internal/status", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ status: "PAID" }),
+			}),
+			{ params: Promise.resolve({ id: "ord_internal" }) },
+		);
+
+		expect(response.status).toBe(409);
 	});
 });

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -18,13 +18,13 @@ export async function POST(
 	const supabase = getSupabaseAdmin();
 	const { data, error } = await supabase
 		.from("orders")
-		.select("payload")
+		.select("status, payload")
 		.eq("id", id)
 		.single();
 
 	if (error || !data) return new NextResponse("Not found", { status: 404 });
 
-	const previous = data.payload as OrderRecord;
+	const previous = { ...(data.payload as OrderRecord), status: data.status as OrderStatus };
 	if (previous.status !== status && !isValidOrderStatusTransition(previous.status, status)) {
 		return NextResponse.json(
 			{
@@ -35,13 +35,29 @@ export async function POST(
 	}
 
 	const updated: OrderRecord = { ...previous, status };
+	if (status === "CANCELED") {
+		const { data: cancellation, error: cancelError } = await supabase.rpc("cancel_order_and_restore_inventory", {
+			p_order_id: id,
+		});
+		if (cancelError) {
+			return NextResponse.json({ error: cancelError.message }, { status: 400 });
+		}
+		if (cancellation?.restored !== false) notifyStatusChange(updated).catch(console.warn);
+		return NextResponse.json({ ok: true });
+	}
 
-	const { error: upErr } = await supabase
+	const { data: changed, error: upErr } = await supabase
 		.from("orders")
 		.update({ status, payload: updated })
-		.eq("id", id);
+		.eq("id", id)
+		.eq("status", previous.status)
+		.select("id")
+		.maybeSingle();
 
 	if (upErr) return NextResponse.json({ error: upErr.message }, { status: 400 });
+	if (!changed) {
+		return NextResponse.json({ error: "Order status changed; refresh and try again" }, { status: 409 });
+	}
 
 	notifyStatusChange(updated).catch(console.warn);
 	return NextResponse.json({ ok: true });

--- a/app/api/orders/route.test.ts
+++ b/app/api/orders/route.test.ts
@@ -1,15 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockFrom, mockInsert, mockInventorySelect, mockRpc } = vi.hoisted(() => ({
-	mockFrom: vi.fn(),
-	mockInsert: vi.fn(),
-	mockInventorySelect: vi.fn(),
-	mockRpc: vi.fn(),
-}));
+const { mockRpc } = vi.hoisted(() => ({ mockRpc: vi.fn() }));
 
 vi.mock("@/lib/supabaseAdmin", () => ({
-	getSupabaseAdmin: () => ({ from: mockFrom, rpc: mockRpc }),
+	getSupabaseAdmin: () => ({ rpc: mockRpc }),
 }));
 vi.mock("@/lib/notify", () => ({ notifyNewOrder: vi.fn().mockResolvedValue(undefined) }));
 vi.mock("@/lib/rateLimit", () => ({ checkRateLimit: () => null }));
@@ -33,44 +28,30 @@ function orderRequest() {
 describe("POST /api/orders", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockFrom.mockImplementation((table: string) => {
-			if (table === "inventory_slots") return { select: mockInventorySelect };
-			if (table === "orders") return { insert: mockInsert };
-			throw new Error(`Unexpected table ${table}`);
-		});
 		mockRpc.mockResolvedValue({ error: null });
-		mockInsert.mockResolvedValue({ error: null });
 	});
 
-	it("passes a separate tracking token through the atomic inventory RPC", async () => {
-		mockInventorySelect.mockResolvedValue({ data: [{ id: "slot" }] });
-
+	it("always creates through the atomic inventory RPC", async () => {
 		const response = await POST(orderRequest());
 		const body = await response.json();
 		const rpcArgs = mockRpc.mock.calls[0][1];
 
 		expect(response.status).toBe(201);
+		expect(mockRpc).toHaveBeenCalledTimes(1);
 		expect(mockRpc).toHaveBeenCalledWith("create_order_with_reserve", expect.objectContaining({
 			p_order_id: expect.stringMatching(/^ord_/),
 			p_tracking_token: body.trackingToken,
+			p_items: [{ id: "cake", qty: 1 }],
 		}));
-		expect(body).toEqual({ trackingToken: expect.any(String) });
 		expect(rpcArgs.p_tracking_token).not.toBe(rpcArgs.p_order_id);
-		expect(body).not.toHaveProperty("id");
 	});
 
-	it("stores the tracking token on direct inserts when inventory is not configured", async () => {
-		mockInventorySelect.mockResolvedValue({ data: [] });
+	it("fails closed when the reservation RPC rejects the order", async () => {
+		mockRpc.mockResolvedValue({ data: null, error: { message: "Item cake: inventory state is missing" } });
 
 		const response = await POST(orderRequest());
-		const body = await response.json();
 
-		expect(response.status).toBe(201);
-		expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
-			id: expect.stringMatching(/^ord_/),
-			tracking_token: body.trackingToken,
-		}));
-		expect(body).toEqual({ trackingToken: expect.any(String) });
-		expect(body).not.toHaveProperty("id");
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Item cake: inventory state is missing" });
 	});
 });

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -28,9 +28,6 @@ export async function POST(req: NextRequest) {
 		const trackingToken = createTrackingToken();
 		const supabase = getSupabaseAdmin();
 
-		const { data: slots } = await supabase.from("inventory_slots").select("id");
-		const hasInventory = Array.isArray(slots) && slots.length > 0;
-
 		const order: OrderRecord = {
 			id,
 			createdAt: new Date().toISOString(),
@@ -40,30 +37,16 @@ export async function POST(req: NextRequest) {
 			totals: orderData.totals,
 		};
 
-		if (hasInventory) {
-			// Atomic: reserve inventory + insert order in one transaction. Prevents overselling.
-			const itemsPayload = orderData.items.map((i) => ({ id: i.id, qty: i.qty }));
-			const { error } = await supabase.rpc("create_order_with_reserve", {
-				p_order_id: id,
-				p_tracking_token: trackingToken,
-				p_payload: order,
-				p_items: itemsPayload,
-			});
+		const itemsPayload = orderData.items.map((i) => ({ id: i.id, qty: i.qty }));
+		const { error } = await supabase.rpc("create_order_with_reserve", {
+			p_order_id: id,
+			p_tracking_token: trackingToken,
+			p_payload: order,
+			p_items: itemsPayload,
+		});
 
-			if (error) {
-				const msg = error.message ?? "Order failed";
-				// PostgreSQL raises "Item X: only N available" on oversell
-				return NextResponse.json({ error: msg }, { status: 400 });
-			}
-		} else {
-			// No inventory slots: insert order only (e.g. before admin sets up inventory)
-			const { error } = await supabase.from("orders").insert({
-				id: order.id,
-				tracking_token: trackingToken,
-				status: order.status,
-				payload: order,
-			});
-			if (error) throw error;
+		if (error) {
+			return NextResponse.json({ error: error.message ?? "Order failed" }, { status: 400 });
 		}
 
 		notifyNewOrder(order).catch(console.warn);

--- a/lib/inventory.test.ts
+++ b/lib/inventory.test.ts
@@ -1,128 +1,16 @@
-import { describe, it, expect } from "vitest";
-import {
-	getWeekStart,
-	getMonthStart,
-	getRemaining,
-	findRelevantSlot,
-	validateOrderAgainstSlots,
-	type InventorySlot,
-} from "./inventory";
+import { describe, expect, it } from "vitest";
+import { getQuantityOnHand, type ProductInventory } from "./inventory";
 
-describe("getWeekStart", () => {
-	it("returns YYYY-MM-DD format", () => {
-		const result = getWeekStart(new Date("2025-03-13T12:00:00"));
-		expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-	});
-
-	it("returns same value for dates in same week", () => {
-		const thursday = getWeekStart(new Date("2025-03-13T12:00:00"));
-		const friday = getWeekStart(new Date("2025-03-14T12:00:00"));
-		expect(thursday).toBe(friday);
-	});
-
-	it("returns different value for adjacent weeks", () => {
-		const week1 = getWeekStart(new Date("2025-03-13T12:00:00"));
-		const week2 = getWeekStart(new Date("2025-03-20T12:00:00"));
-		expect(week1).not.toBe(week2);
-	});
-});
-
-describe("getMonthStart", () => {
-	it("returns first of month", () => {
-		expect(getMonthStart(new Date("2025-03-15T12:00:00"))).toBe("2025-03-01");
-	});
-
-	it("returns YYYY-MM-DD format", () => {
-		const result = getMonthStart(new Date("2025-03-13T12:00:00"));
-		expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-	});
-});
-
-describe("getRemaining", () => {
-	it("returns available minus sold", () => {
-		const slot: InventorySlot = {
-			id: "1",
-			item_id: "cake",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 10,
-			quantity_sold: 3,
-		};
-		expect(getRemaining(slot)).toBe(7);
-	});
-
-	it("returns 0 when sold exceeds available", () => {
-		const slot: InventorySlot = {
-			id: "1",
-			item_id: "cake",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 5,
-			quantity_sold: 10,
-		};
-		expect(getRemaining(slot)).toBe(0);
-	});
-});
-
-describe("findRelevantSlot", () => {
-	it("prefers week slot over month when both match", () => {
-		const now = new Date("2025-03-13T12:00:00");
-		const weekStart = getWeekStart(now);
-		const monthStart = getMonthStart(now);
-		const slots: InventorySlot[] = [
-			{ id: "1", item_id: "cake", period_type: "month", period_start: monthStart, quantity_available: 100, quantity_sold: 0 },
-			{ id: "2", item_id: "cake", period_type: "week", period_start: weekStart, quantity_available: 10, quantity_sold: 0 },
+describe("getQuantityOnHand", () => {
+	it("returns the current on-hand quantity", () => {
+		const inventory: ProductInventory[] = [
+			{ product_id: "cake", quantity_on_hand: 7 },
 		];
-		const found = findRelevantSlot(slots, "cake", now);
-		expect(found?.period_type).toBe("week");
+
+		expect(getQuantityOnHand(inventory, "cake")).toBe(7);
 	});
 
-	it("returns month slot when no week slot", () => {
-		const now = new Date("2025-03-13T12:00:00");
-		const monthStart = getMonthStart(now);
-		const slots: InventorySlot[] = [
-			{ id: "1", item_id: "cake", period_type: "month", period_start: monthStart, quantity_available: 100, quantity_sold: 0 },
-		];
-		const found = findRelevantSlot(slots, "cake", now);
-		expect(found?.period_type).toBe("month");
-	});
-
-	it("returns null when no matching slot", () => {
-		const now = new Date("2025-03-13T12:00:00");
-		const weekStart = getWeekStart(now);
-		const slots: InventorySlot[] = [
-			{ id: "1", item_id: "other", period_type: "week", period_start: weekStart, quantity_available: 10, quantity_sold: 0 },
-		];
-		expect(findRelevantSlot(slots, "cake", now)).toBeNull();
-	});
-});
-
-describe("validateOrderAgainstSlots", () => {
-	const now = new Date("2025-03-13T12:00:00");
-	const weekStart = getWeekStart(now);
-	const slots: InventorySlot[] = [
-		{
-			id: "1",
-			item_id: "cake",
-			period_type: "week",
-			period_start: weekStart,
-			quantity_available: 5,
-			quantity_sold: 2,
-		},
-	];
-
-	it("returns null when order is valid", () => {
-		expect(validateOrderAgainstSlots(slots, [{ id: "cake", qty: 3 }], now)).toBeNull();
-	});
-
-	it("returns error when qty exceeds remaining", () => {
-		const err = validateOrderAgainstSlots(slots, [{ id: "cake", qty: 5 }], now);
-		expect(err).toBeTruthy();
-		expect(err).toContain("cake");
-		expect(err).toContain("3");
-	});
-
-	it("returns null for items without slot (unlimited)", () => {
-		expect(validateOrderAgainstSlots(slots, [{ id: "unlimited_item", qty: 100 }], now)).toBeNull();
+	it("fails closed when inventory state is missing", () => {
+		expect(getQuantityOnHand([], "cake")).toBe(0);
 	});
 });

--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -1,88 +1,11 @@
-/**
- * Inventory helpers: period computation and availability logic.
- * Works with inventory_slots table (item_id, period_type, period_start, quantity_available, quantity_sold).
- */
-
-export type PeriodType = "week" | "month";
-
-export type InventorySlot = {
-	id: string;
-	item_id: string;
-	period_type: PeriodType;
-	period_start: string;
-	quantity_available: number;
-	quantity_sold: number;
-	created_at?: string;
+/** One authoritative current stock row for a product. */
+export type ProductInventory = {
+	product_id: string;
+	quantity_on_hand: number;
+	updated_at?: string;
 };
 
-/** Start of week (Monday) for a given date, ISO string */
-export function getWeekStart(d: Date): string {
-	const date = new Date(d);
-	const day = date.getDay();
-	const diff = date.getDate() - day + (day === 0 ? -6 : 1);
-	date.setDate(diff);
-	return date.toISOString().slice(0, 10);
-}
-
-/** First day of month for a given date, ISO string */
-export function getMonthStart(d: Date): string {
-	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
-}
-
-/** Remaining quantity for an item in a slot */
-export function getRemaining(slot: InventorySlot): number {
-	return Math.max(0, slot.quantity_available - slot.quantity_sold);
-}
-
-/** Whether an item is available (has remaining quantity) in the given slot */
-export function isSlotAvailable(slot: InventorySlot): boolean {
-	return getRemaining(slot) > 0;
-}
-
-/**
- * Find the best-matching slot for current period.
- * Prefers week over month if both exist (more granular).
- */
-export function findRelevantSlot(
-	slots: InventorySlot[],
-	itemId: string,
-	now: Date
-): InventorySlot | null {
-	const weekStart = getWeekStart(now);
-	const monthStart = getMonthStart(now);
-
-	const weekSlot = slots.find(
-		(s) => s.item_id === itemId && s.period_type === "week" && s.period_start === weekStart
-	);
-	if (weekSlot) return weekSlot;
-
-	const monthSlot = slots.find(
-		(s) => s.item_id === itemId && s.period_type === "month" && s.period_start === monthStart
-	);
-	if (monthSlot) return monthSlot;
-
-	return null;
-}
-
-export type OrderItemQty = { id: string; qty: number };
-
-/**
- * Validate that order items can be fulfilled from inventory.
- * Returns error message if any item exceeds available quantity.
- */
-export function validateOrderAgainstSlots(
-	slots: InventorySlot[],
-	items: OrderItemQty[],
-	now: Date
-): string | null {
-	for (const item of items) {
-		const slot = findRelevantSlot(slots, item.id, now);
-		if (slot) {
-			const remaining = getRemaining(slot);
-			if (item.qty > remaining) {
-				return `Item ${item.id}: only ${remaining} available`;
-			}
-		}
-	}
-	return null;
+/** Missing inventory is treated as zero so all read paths fail closed. */
+export function getQuantityOnHand(inventory: ProductInventory[], productId: string): number {
+	return inventory.find((row) => row.product_id === productId)?.quantity_on_hand ?? 0;
 }

--- a/lib/inventoryBulk.test.ts
+++ b/lib/inventoryBulk.test.ts
@@ -1,159 +1,50 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-	parseCsvLine,
+	parseInventoryBulkJson,
 	parseInventoryCsv,
 	stringifyInventoryCsv,
+	stringifyInventoryTemplateCsv,
 	validateBulkRow,
-	parseInventoryBulkJson,
-	type InventoryBulkRow,
 } from "./inventoryBulk";
-import type { InventorySlot } from "./inventory";
 
-describe("parseCsvLine", () => {
-	it("splits simple comma fields", () => {
-		expect(parseCsvLine("a,b,c,d")).toEqual(["a", "b", "c", "d"]);
-	});
-
-	it("handles quoted commas", () => {
-		expect(parseCsvLine('"a,b",week,2025-03-01,5')).toEqual(["a,b", "week", "2025-03-01", "5"]);
-	});
-});
-
-describe("parseInventoryCsv", () => {
-	it("parses rows and skips header", () => {
-		const csv = `item_id,period_type,period_start,quantity_available
-cake,week,2025-03-10,12
-pie,month,2025-03-01,3`;
-		const r = parseInventoryCsv(csv);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows).toHaveLength(2);
-		expect(r.rows[0]).toMatchObject({
-			item_id: "cake",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 12,
+describe("current inventory bulk helpers", () => {
+	it("parses current on-hand CSV", () => {
+		const result = parseInventoryCsv("product_id,quantity_on_hand\ncake,12\npie,3");
+		expect(result).toEqual({
+			ok: true,
+			rows: [
+				{ product_id: "cake", quantity_on_hand: 12 },
+				{ product_id: "pie", quantity_on_hand: 3 },
+			],
 		});
 	});
 
-	it("strips BOM", () => {
-		const csv = "\uFEFFitem_id,period_type,period_start,quantity_available\nx,week,2025-03-10,1";
-		const r = parseInventoryCsv(csv);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows[0]?.item_id).toBe("x");
-	});
-
-	it("rejects empty file", () => {
-		const r = parseInventoryCsv("");
-		expect(r.ok).toBe(false);
-	});
-
-	it("parses 5-column template with item_name", () => {
-		const csv = `item_id,item_name,period_type,period_start,quantity_available
-brownie,Brownie bite,week,2025-03-10,5`;
-		const r = parseInventoryCsv(csv);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows[0]).toMatchObject({
-			item_id: "brownie",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 5,
+	it("round-trips exports", () => {
+		const csv = stringifyInventoryCsv([{ product_id: "cake", quantity_on_hand: 5 }]);
+		expect(parseInventoryCsv(csv)).toEqual({
+			ok: true,
+			rows: [{ product_id: "cake", quantity_on_hand: 5 }],
 		});
 	});
 
-	it("parses 5-column export round-trip (period in column 2)", () => {
-		const csv = `item_id,period_type,period_start,quantity_available,quantity_sold
-cake,week,2025-03-10,5,2`;
-		const r = parseInventoryCsv(csv);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows[0]).toMatchObject({
-			item_id: "cake",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 5,
+	it("creates and parses a product-name template", () => {
+		const csv = stringifyInventoryTemplateCsv([{ product_id: "cake", product_name: "Cake, large" }]);
+		expect(parseInventoryCsv(csv)).toEqual({
+			ok: true,
+			rows: [{ product_id: "cake", quantity_on_hand: 0 }],
 		});
 	});
-});
 
-describe("stringifyInventoryCsv / round-trip", () => {
-	it("exports and re-parses", () => {
-		const slots: InventorySlot[] = [
-			{
-				id: "u1",
-				item_id: "cake",
-				period_type: "week",
-				period_start: "2025-03-10",
-				quantity_available: 5,
-				quantity_sold: 2,
-			},
-		];
-		const csv = stringifyInventoryCsv(slots);
-		const r = parseInventoryCsv(csv);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows[0]).toMatchObject({
-			item_id: "cake",
-			period_type: "week",
-			period_start: "2025-03-10",
-			quantity_available: 5,
+	it("rejects negative, fractional, and invalid quantities", () => {
+		for (const quantity_on_hand of [-1, 1.5, Number.NaN]) {
+			expect(validateBulkRow({ product_id: "cake", quantity_on_hand }, 0).ok).toBe(false);
+		}
+	});
+
+	it("parses JSON rows", () => {
+		expect(parseInventoryBulkJson([{ product_id: "cake", quantity_on_hand: 4 }])).toEqual({
+			ok: true,
+			rows: [{ product_id: "cake", quantity_on_hand: 4 }],
 		});
-	});
-});
-
-describe("validateBulkRow", () => {
-	it("accepts valid row", () => {
-		const row: InventoryBulkRow = {
-			item_id: "a",
-			period_type: "week",
-			period_start: "2025-01-01",
-			quantity_available: 0,
-		};
-		const v = validateBulkRow(row, 0);
-		expect(v.ok).toBe(true);
-		if (!v.ok) return;
-		expect(v.row.quantity_available).toBe(0);
-	});
-
-	it("normalizes period casing", () => {
-		const row: InventoryBulkRow = {
-			item_id: "a",
-			period_type: "Week" as InventoryBulkRow["period_type"],
-			period_start: "2025-01-01",
-			quantity_available: 1,
-		};
-		const v = validateBulkRow(row, 0);
-		expect(v.ok).toBe(true);
-		if (!v.ok) return;
-		expect(v.row.period_type).toBe("week");
-	});
-
-	it("rejects bad date", () => {
-		const row: InventoryBulkRow = {
-			item_id: "a",
-			period_type: "week",
-			period_start: "01-01-2025",
-			quantity_available: 1,
-		};
-		const v = validateBulkRow(row, 0);
-		expect(v.ok).toBe(false);
-	});
-});
-
-describe("parseInventoryBulkJson", () => {
-	it("parses array of objects", () => {
-		const r = parseInventoryBulkJson([
-			{ item_id: "x", period_type: "week", period_start: "2025-03-01", quantity_available: 2 },
-		]);
-		expect(r.ok).toBe(true);
-		if (!r.ok) return;
-		expect(r.rows[0]?.item_id).toBe("x");
-	});
-
-	it("rejects non-array", () => {
-		const r = parseInventoryBulkJson({});
-		expect(r.ok).toBe(false);
 	});
 });

--- a/lib/inventoryBulk.ts
+++ b/lib/inventoryBulk.ts
@@ -1,240 +1,103 @@
-/**
- * CSV / JSON bulk helpers for inventory_slots import/export.
- */
-import type { InventorySlot } from "@/lib/inventory";
+import type { ProductInventory } from "@/lib/inventory";
 
 export type InventoryBulkRow = {
-	item_id: string;
-	period_type: "week" | "month";
-	period_start: string;
-	quantity_available: number;
+	product_id: string;
+	quantity_on_hand: number;
 };
-
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-/** Normalize values from CSV/JSON before validation. */
-export function normalizeBulkRow(row: InventoryBulkRow): InventoryBulkRow {
-	const pt = String(row.period_type).trim().toLowerCase();
-	return {
-		item_id: String(row.item_id).trim(),
-		period_type: pt as "week" | "month",
-		period_start: String(row.period_start).trim(),
-		quantity_available: row.quantity_available,
-	};
-}
 
 export function validateBulkRow(
 	row: InventoryBulkRow,
 	index: number
 ): { ok: true; row: InventoryBulkRow } | { ok: false; index: number; message: string } {
-	const n = normalizeBulkRow(row);
-	if (!n.item_id) {
-		return { ok: false, index, message: "item_id is required" };
+	const productId = String(row.product_id).trim();
+	const quantityOnHand = Number(row.quantity_on_hand);
+	if (!productId) return { ok: false, index, message: "product_id is required" };
+	if (!Number.isSafeInteger(quantityOnHand) || quantityOnHand < 0 || quantityOnHand > 2147483647) {
+		return { ok: false, index, message: "quantity_on_hand must be a non-negative integer" };
 	}
-	if (n.period_type !== "week" && n.period_type !== "month") {
-		return { ok: false, index, message: "period_type must be week or month" };
-	}
-	if (!DATE_RE.test(n.period_start)) {
-		return { ok: false, index, message: "period_start must be YYYY-MM-DD" };
-	}
-	const q = Number(n.quantity_available);
-	if (!Number.isFinite(q) || q < 0) {
-		return { ok: false, index, message: "quantity_available must be a non-negative number" };
-	}
-	return { ok: true, row: { ...n, quantity_available: q } };
+	return { ok: true, row: { product_id: productId, quantity_on_hand: quantityOnHand } };
 }
 
-/** Escape a field for CSV (RFC-style: quote if needed). */
 export function escapeCsvField(value: string): string {
-	if (/[",\n\r]/.test(value)) {
-		return `"${value.replace(/"/g, '""')}"`;
-	}
-	return value;
+	return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
 }
 
-/**
- * Parse one CSV line into fields (handles quoted segments).
- */
 export function parseCsvLine(line: string): string[] {
 	const fields: string[] = [];
-	let cur = "";
-	let i = 0;
+	let current = "";
 	let inQuotes = false;
-	while (i < line.length) {
-		const c = line[i];
-		if (inQuotes) {
-			if (c === '"') {
-				if (line[i + 1] === '"') {
-					cur += '"';
-					i += 2;
-					continue;
-				}
-				inQuotes = false;
-				i += 1;
-				continue;
+	for (let i = 0; i < line.length; i++) {
+		const character = line[i];
+		if (character === '"') {
+			if (inQuotes && line[i + 1] === '"') {
+				current += '"';
+				i++;
+			} else {
+				inQuotes = !inQuotes;
 			}
-			cur += c;
-			i += 1;
-			continue;
+		} else if (character === "," && !inQuotes) {
+			fields.push(current.trim());
+			current = "";
+		} else {
+			current += character;
 		}
-		if (c === '"') {
-			inQuotes = true;
-			i += 1;
-			continue;
-		}
-		if (c === ",") {
-			fields.push(cur);
-			cur = "";
-			i += 1;
-			continue;
-		}
-		cur += c;
-		i += 1;
 	}
-	fields.push(cur);
-	return fields.map((f) => f.trim());
+	fields.push(current.trim());
+	return fields;
 }
 
 export type BulkRowsParseResult =
 	| { ok: true; rows: InventoryBulkRow[] }
 	| { ok: false; message: string };
 
-/**
- * Parse bulk inventory CSV. Expected columns:
- * item_id, period_type, period_start, quantity_available
- * Optional 5th column quantity_sold (ignored for import).
- */
 export function parseInventoryCsv(text: string): BulkRowsParseResult {
-	const raw = text.replace(/^\uFEFF/, "");
-	const lines = raw.split(/\r?\n/).map((l) => l.trimEnd());
+	const lines = text.replace(/^\uFEFF/, "").split(/\r?\n/).filter((line) => line.trim());
+	if (lines.length === 0) return { ok: false, message: "CSV is empty" };
+	const start = lines[0]?.toLowerCase().includes("product_id") ? 1 : 0;
 	const rows: InventoryBulkRow[] = [];
-	let start = 0;
-
-	if (lines.length === 0 || (lines.length === 1 && lines[0] === "")) {
-		return { ok: false, message: "CSV is empty" };
-	}
-
-	const first = lines[0] ?? "";
-	const firstLower = first.toLowerCase();
-	if (
-		firstLower.startsWith("item_id") ||
-		firstLower.includes("period_type") ||
-		firstLower.includes("quantity_available")
-	) {
-		start = 1;
-	}
-
-	for (let li = start; li < lines.length; li++) {
-		const line = lines[li]?.trim() ?? "";
-		if (!line) continue;
-		const fields = parseCsvLine(line);
-		if (fields.length < 4) {
-			return { ok: false, message: `Line ${li + 1}: need at least 4 columns` };
+	for (let index = start; index < lines.length; index++) {
+		const fields = parseCsvLine(lines[index]!);
+		if (fields.length !== 2 && fields.length !== 3) {
+			return { ok: false, message: `Line ${index + 1}: expected product_id,quantity_on_hand` };
 		}
-		let item_id: string;
-		let period_type: string;
-		let period_start: string;
-		let qtyRaw: string;
-
-		if (fields.length === 4) {
-			[item_id, period_type, period_start, qtyRaw] = fields;
-		} else {
-			const second = fields[1]?.trim().toLowerCase() ?? "";
-			const isExportStyle = second === "week" || second === "month";
-			if (isExportStyle) {
-				/** Export: item_id, period_type, period_start, quantity_available, quantity_sold */
-				item_id = fields[0]!;
-				period_type = fields[1]!;
-				period_start = fields[2]!;
-				qtyRaw = fields[3]!;
-			} else {
-				/** Template: item_id, item_name, period_type, period_start, quantity_available */
-				if (fields.length < 5) {
-					return { ok: false, message: `Line ${li + 1}: need 5 columns when using item_name` };
-				}
-				item_id = fields[0]!;
-				period_type = fields[2]!;
-				period_start = fields[3]!;
-				qtyRaw = fields[4]!;
-			}
-		}
-		const pt = period_type.trim().toLowerCase();
-		if (pt !== "week" && pt !== "month") {
-			return { ok: false, message: `Line ${li + 1}: period_type must be week or month` };
-		}
-		const qty = Number(String(qtyRaw).replace(/,/g, ""));
-		if (!Number.isFinite(qty)) {
-			return { ok: false, message: `Line ${li + 1}: quantity_available must be a number` };
-		}
-		rows.push({
-			item_id: item_id.trim(),
-			period_type: pt,
-			period_start: period_start.trim(),
-			quantity_available: qty,
-		});
+		const quantity = fields.length === 2 ? fields[1] : fields[2];
+		rows.push({ product_id: fields[0]!, quantity_on_hand: quantity === "" ? Number.NaN : Number(quantity) });
 	}
-
-	if (rows.length === 0) {
-		return { ok: false, message: "No data rows found" };
-	}
-	return { ok: true, rows };
+	return rows.length > 0 ? { ok: true, rows } : { ok: false, message: "No data rows found" };
 }
 
-export function stringifyInventoryCsv(slots: InventorySlot[]): string {
-	const header = "item_id,period_type,period_start,quantity_available,quantity_sold";
-	const lines = slots.map((s) =>
-		[
-			escapeCsvField(s.item_id),
-			escapeCsvField(s.period_type),
-			escapeCsvField(s.period_start),
-			String(s.quantity_available),
-			String(s.quantity_sold),
-		].join(",")
+export function stringifyInventoryCsv(rows: ProductInventory[]): string {
+	const lines = rows.map((row) =>
+		`${escapeCsvField(row.product_id)},${row.quantity_on_hand}`
 	);
-	return [header, ...lines].join("\r\n") + "\r\n";
+	return ["product_id,quantity_on_hand", ...lines].join("\r\n") + "\r\n";
 }
 
-/** CSV template: optional human-readable name column for spreadsheets (ignored on import). */
-export function stringifyWeekTemplateCsv(
-	rows: { item_id: string; item_name: string }[],
-	periodStart: string
+export function stringifyInventoryTemplateCsv(
+	rows: { product_id: string; product_name: string }[]
 ): string {
-	const header = "item_id,item_name,period_type,period_start,quantity_available";
-	const lines = rows.map((r) =>
-		[
-			escapeCsvField(r.item_id),
-			escapeCsvField(r.item_name),
-			"week",
-			escapeCsvField(periodStart),
-			"0",
-		].join(",")
+	const lines = rows.map((row) =>
+		`${escapeCsvField(row.product_id)},${escapeCsvField(row.product_name)},0`
 	);
-	return [header, ...lines].join("\r\n") + "\r\n";
+	return ["product_id,product_name,quantity_on_hand", ...lines].join("\r\n") + "\r\n";
 }
 
-/**
- * Parse JSON array from bulk import. Each object needs item_id, period_type, period_start, quantity_available.
- */
 export function parseInventoryBulkJson(data: unknown): BulkRowsParseResult {
-	if (!Array.isArray(data)) {
-		return { ok: false, message: "JSON must be an array of row objects" };
-	}
+	if (!Array.isArray(data)) return { ok: false, message: "JSON must be an array of row objects" };
+	if (data.length === 0) return { ok: false, message: "Array is empty" };
 	const rows: InventoryBulkRow[] = [];
-	for (let i = 0; i < data.length; i++) {
-		const item = data[i];
-		if (!item || typeof item !== "object") {
-			return { ok: false, message: `Row ${i + 1}: must be an object` };
+	for (let index = 0; index < data.length; index++) {
+		const value = data[index];
+		if (!value || typeof value !== "object") {
+			return { ok: false, message: `Row ${index + 1}: must be an object` };
 		}
-		const o = item as Record<string, unknown>;
+		const object = value as Record<string, unknown>;
 		rows.push({
-			item_id: String(o.item_id ?? ""),
-			period_type: String(o.period_type ?? "") as InventoryBulkRow["period_type"],
-			period_start: String(o.period_start ?? ""),
-			quantity_available: Number(o.quantity_available),
+			product_id: String(object.product_id ?? ""),
+			quantity_on_hand: object.quantity_on_hand === null || object.quantity_on_hand === undefined
+				? Number.NaN
+				: Number(object.quantity_on_hand),
 		});
-	}
-	if (rows.length === 0) {
-		return { ok: false, message: "Array is empty" };
 	}
 	return { ok: true, rows };
 }

--- a/lib/inventoryUpsert.ts
+++ b/lib/inventoryUpsert.ts
@@ -1,49 +1,22 @@
-/**
- * Upsert a single inventory slot (same behavior as POST /api/admin/inventory).
- */
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import type { InventorySlot } from "@/lib/inventory";
+import type { ProductInventory } from "@/lib/inventory";
 
-export type UpsertInventoryInput = {
-	item_id: string;
-	period_type: "week" | "month";
-	period_start: string;
-	quantity_available: number;
+export type SetProductInventoryInput = {
+	product_id: string;
+	quantity_on_hand: number;
 };
 
-export async function upsertInventorySlot(
-	row: UpsertInventoryInput
-): Promise<{ ok: true; data: InventorySlot; created: boolean } | { ok: false; error: string }> {
-	const { item_id, period_type, period_start } = row;
-	const qty = Math.max(0, Math.floor(Number(row.quantity_available)));
-
-	const { data: existing } = await supabaseAdmin
-		.from("inventory_slots")
-		.select("id")
-		.eq("item_id", item_id)
-		.eq("period_type", period_type)
-		.eq("period_start", period_start)
+export async function setProductInventory(
+	row: SetProductInventoryInput
+): Promise<{ ok: true; data: ProductInventory } | { ok: false; error: string }> {
+	const { data, error } = await supabaseAdmin
+		.from("product_inventory")
+		.update({ quantity_on_hand: row.quantity_on_hand })
+		.eq("product_id", row.product_id)
+		.select()
 		.maybeSingle();
 
-	if (existing) {
-		const { data, error } = await supabaseAdmin
-			.from("inventory_slots")
-			.update({ quantity_available: qty })
-			.eq("id", existing.id)
-			.select()
-			.single();
-		if (error) return { ok: false, error: error.message };
-		if (!data) return { ok: false, error: "Update returned no row" };
-		return { ok: true, data: data as InventorySlot, created: false };
-	}
-
-	const { data, error } = await supabaseAdmin
-		.from("inventory_slots")
-		.insert({ item_id, period_type, period_start, quantity_available: qty, quantity_sold: 0 })
-		.select()
-		.single();
-
 	if (error) return { ok: false, error: error.message };
-	if (!data) return { ok: false, error: "Insert returned no row" };
-	return { ok: true, data: data as InventorySlot, created: true };
+	if (!data) return { ok: false, error: `Product ${row.product_id}: inventory state is missing` };
+	return { ok: true, data: data as ProductInventory };
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run",
+		"test": "vitest run",
+		"test:db": "bash scripts/test-inventory-db.sh",
     "test:smoke": "node scripts/smoke.mjs",
     "test:watch": "vitest"
   },

--- a/scripts/test-inventory-db.sh
+++ b/scripts/test-inventory-db.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container="little-town-bakes-inventory-test-$$"
+database="little_town_bakes_test"
+results_dir="$(mktemp -d /tmp/little-town-bakes-inventory.XXXXXX)"
+
+cleanup() {
+    docker stop "$container" >/dev/null 2>&1 || true
+    rm -rf "$results_dir"
+}
+trap cleanup EXIT
+
+docker run --rm -d --name "$container" \
+    -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB="$database" \
+    postgres:17 >/dev/null
+
+for _ in $(seq 1 30); do
+    if docker exec "$container" pg_isready -U postgres -d "$database" >/dev/null 2>&1; then break; fi
+    sleep 1
+done
+docker exec "$container" pg_isready -U postgres -d "$database" >/dev/null
+
+docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" <<'SQL'
+CREATE ROLE anon NOLOGIN;
+CREATE ROLE authenticated NOLOGIN;
+CREATE ROLE service_role NOLOGIN;
+SQL
+
+for migration in supabase/migrations/*.sql; do
+    docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" < "$migration" >/dev/null
+done
+docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
+    < supabase/tests/current_product_inventory.sql >/dev/null
+
+reservation_one="SELECT public.create_order_with_reserve('race_1','track_race_1','{\"items\":[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]}'::jsonb,'[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]'::jsonb);"
+reservation_two="SELECT public.create_order_with_reserve('race_2','track_race_2','{\"items\":[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]}'::jsonb,'[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]'::jsonb);"
+
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$reservation_one" >"$results_dir/one" 2>&1 &
+pid_one=$!
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$reservation_two" >"$results_dir/two" 2>&1 &
+pid_two=$!
+
+successes=0
+if wait "$pid_one"; then successes=$((successes + 1)); fi
+if wait "$pid_two"; then successes=$((successes + 1)); fi
+
+final_quantity="$(docker exec "$container" psql -At -U postgres -d "$database" -c "SELECT quantity_on_hand FROM public.product_inventory WHERE product_id = 'cookie_chocolatechip';")"
+race_orders="$(docker exec "$container" psql -At -U postgres -d "$database" -c "SELECT count(*) FROM public.orders WHERE id LIKE 'race_%';")"
+
+if [[ "$successes" -ne 1 || "$final_quantity" -ne 0 || "$race_orders" -ne 1 ]]; then
+    cat "$results_dir/one" "$results_dir/two"
+    echo "race assertion failed: successes=$successes stock=$final_quantity orders=$race_orders" >&2
+    exit 1
+fi
+
+echo "Inventory database tests passed (last-unit race: 1 success, 1 rejection, final stock 0)."

--- a/supabase/migrations/20260909150000_current_product_inventory.sql
+++ b/supabase/migrations/20260909150000_current_product_inventory.sql
@@ -1,0 +1,247 @@
+-- Replace period inventory with one authoritative current on-hand quantity.
+-- This is a prelaunch reset: old week/month quantities are intentionally discarded.
+
+DROP FUNCTION IF EXISTS public.create_order_with_reserve(TEXT, JSONB, JSONB);
+DROP FUNCTION IF EXISTS public.create_order_with_reserve(TEXT, TEXT, JSONB, JSONB);
+DROP TABLE IF EXISTS public.inventory_slots;
+
+CREATE TABLE public.product_inventory (
+    product_id TEXT PRIMARY KEY REFERENCES public.products (id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+    quantity_on_hand INTEGER NOT NULL DEFAULT 0 CHECK (quantity_on_hand >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE FUNCTION public.set_product_inventory_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER product_inventory_set_updated_at
+    BEFORE UPDATE ON public.product_inventory
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_product_inventory_updated_at();
+
+CREATE FUNCTION public.create_product_inventory()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+    INSERT INTO public.product_inventory (product_id, quantity_on_hand)
+    VALUES (NEW.id, 0);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER products_create_inventory
+    AFTER INSERT ON public.products
+    FOR EACH ROW
+    EXECUTE FUNCTION public.create_product_inventory();
+
+INSERT INTO public.product_inventory (product_id, quantity_on_hand)
+SELECT id, 0
+FROM public.products
+ON CONFLICT (product_id) DO NOTHING;
+
+ALTER TABLE public.product_inventory ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.product_inventory FROM anon, authenticated;
+REVOKE ALL ON FUNCTION public.set_product_inventory_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_product_inventory() FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.product_inventory TO service_role;
+
+CREATE FUNCTION public.create_order_with_reserve(
+    p_order_id TEXT,
+    p_tracking_token TEXT,
+    p_payload JSONB,
+    p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    item JSONB;
+    requested RECORD;
+    archived BOOLEAN;
+    current_quantity INTEGER;
+    changed_rows INTEGER;
+    numeric_quantity NUMERIC;
+BEGIN
+    IF jsonb_typeof(p_items) IS DISTINCT FROM 'array' OR jsonb_array_length(p_items) = 0 THEN
+        RAISE EXCEPTION 'Order must contain at least one item';
+    END IF;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(p_items)
+    LOOP
+        IF jsonb_typeof(item) IS DISTINCT FROM 'object'
+            OR jsonb_typeof(item->'id') IS DISTINCT FROM 'string'
+            OR btrim(item->>'id') = ''
+            OR jsonb_typeof(item->'qty') IS DISTINCT FROM 'number' THEN
+            RAISE EXCEPTION 'Each order item requires a product id and positive integer quantity';
+        END IF;
+
+        numeric_quantity := (item->>'qty')::numeric;
+        IF numeric_quantity <= 0
+            OR numeric_quantity <> trunc(numeric_quantity)
+            OR numeric_quantity > 2147483647 THEN
+            RAISE EXCEPTION 'Item %: quantity must be a positive integer', item->>'id';
+        END IF;
+    END LOOP;
+
+    -- Aggregate duplicate lines and process products in stable order to avoid deadlocks.
+    FOR requested IN
+        SELECT value->>'id' AS product_id, SUM((value->>'qty')::bigint) AS quantity
+        FROM jsonb_array_elements(p_items)
+        GROUP BY value->>'id'
+        ORDER BY value->>'id'
+    LOOP
+        IF requested.quantity > 2147483647 THEN
+            RAISE EXCEPTION 'Item %: quantity is too large', requested.product_id;
+        END IF;
+
+        SELECT product.is_archived
+        INTO archived
+        FROM public.products AS product
+        WHERE product.id = requested.product_id
+        FOR SHARE;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'Item %: product does not exist', requested.product_id;
+        END IF;
+        IF archived THEN
+            RAISE EXCEPTION 'Item %: product is archived', requested.product_id;
+        END IF;
+
+        SELECT inventory.quantity_on_hand
+        INTO current_quantity
+        FROM public.product_inventory AS inventory
+        WHERE inventory.product_id = requested.product_id
+        FOR UPDATE;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'Item %: inventory state is missing', requested.product_id;
+        END IF;
+
+        UPDATE public.product_inventory
+        SET quantity_on_hand = quantity_on_hand - requested.quantity::integer
+        WHERE product_id = requested.product_id
+          AND quantity_on_hand >= requested.quantity;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+
+        IF changed_rows <> 1 THEN
+            RAISE EXCEPTION 'Item %: only % available', requested.product_id, current_quantity;
+        END IF;
+    END LOOP;
+
+    INSERT INTO public.orders (id, tracking_token, status, payload)
+    VALUES (
+        p_order_id,
+        p_tracking_token,
+        'AWAITING_PAYMENT',
+        jsonb_set(p_payload, '{status}', '"AWAITING_PAYMENT"'::jsonb, true)
+    );
+
+    RETURN jsonb_build_object('id', p_order_id);
+END;
+$$;
+
+CREATE FUNCTION public.cancel_order_and_restore_inventory(p_order_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    order_status TEXT;
+    order_payload JSONB;
+    item JSONB;
+    reserved RECORD;
+    changed_rows INTEGER;
+    numeric_quantity NUMERIC;
+BEGIN
+    SELECT orders.status, orders.payload
+    INTO order_status, order_payload
+    FROM public.orders
+    WHERE orders.id = p_order_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Order % does not exist', p_order_id;
+    END IF;
+    IF order_status = 'CANCELED' THEN
+        RETURN jsonb_build_object('id', p_order_id, 'canceled', true, 'restored', false);
+    END IF;
+    IF order_status = 'COMPLETED' THEN
+        RAISE EXCEPTION 'Completed orders cannot be canceled';
+    END IF;
+
+    IF jsonb_typeof(order_payload->'items') IS DISTINCT FROM 'array' THEN
+        RAISE EXCEPTION 'Order % has invalid reserved items', p_order_id;
+    END IF;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(order_payload->'items')
+    LOOP
+        IF jsonb_typeof(item) IS DISTINCT FROM 'object'
+            OR jsonb_typeof(item->'id') IS DISTINCT FROM 'string'
+            OR btrim(item->>'id') = ''
+            OR jsonb_typeof(item->'qty') IS DISTINCT FROM 'number' THEN
+            RAISE EXCEPTION 'Order % has invalid reserved items', p_order_id;
+        END IF;
+        numeric_quantity := (item->>'qty')::numeric;
+        IF numeric_quantity <= 0
+            OR numeric_quantity <> trunc(numeric_quantity)
+            OR numeric_quantity > 2147483647 THEN
+            RAISE EXCEPTION 'Order % has invalid reserved quantities', p_order_id;
+        END IF;
+    END LOOP;
+
+    FOR reserved IN
+        SELECT value->>'id' AS product_id, SUM((value->>'qty')::bigint) AS quantity
+        FROM jsonb_array_elements(order_payload->'items')
+        GROUP BY value->>'id'
+        ORDER BY value->>'id'
+    LOOP
+        UPDATE public.product_inventory
+        SET quantity_on_hand = quantity_on_hand + reserved.quantity::integer
+        WHERE product_id = reserved.product_id;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+        IF changed_rows <> 1 THEN
+            RAISE EXCEPTION 'Item %: inventory state is missing', reserved.product_id;
+        END IF;
+    END LOOP;
+
+    UPDATE public.orders
+    SET status = 'CANCELED',
+        payload = jsonb_set(order_payload, '{status}', '"CANCELED"'::jsonb, true)
+    WHERE id = p_order_id;
+
+    RETURN jsonb_build_object('id', p_order_id, 'canceled', true, 'restored', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_order_with_reserve(TEXT, TEXT, JSONB, JSONB)
+FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.cancel_order_and_restore_inventory(TEXT)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_order_with_reserve(TEXT, TEXT, JSONB, JSONB)
+TO service_role;
+GRANT EXECUTE ON FUNCTION public.cancel_order_and_restore_inventory(TEXT)
+TO service_role;
+
+COMMENT ON TABLE public.product_inventory IS 'One authoritative current on-hand quantity per product.';
+COMMENT ON FUNCTION public.create_order_with_reserve(TEXT, TEXT, JSONB, JSONB)
+IS 'Atomically validates products, reserves current inventory, and creates an order.';
+COMMENT ON FUNCTION public.cancel_order_and_restore_inventory(TEXT)
+IS 'Atomically cancels a non-completed order and restores its reserved inventory exactly once.';
+COMMENT ON TABLE public.products IS 'Authoritative product catalog; current stock is stored in product_inventory.';

--- a/supabase/tests/current_product_inventory.sql
+++ b/supabase/tests/current_product_inventory.sql
@@ -1,0 +1,185 @@
+CREATE FUNCTION pg_temp.assert_true(condition BOOLEAN, message TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+BEGIN
+    IF NOT condition THEN RAISE EXCEPTION 'assertion failed: %', message; END IF;
+END;
+$$;
+
+SELECT pg_temp.assert_true(
+    (SELECT count(*) = (SELECT count(*) FROM public.products)
+     FROM public.product_inventory),
+    'migration seeds every existing product'
+);
+SELECT pg_temp.assert_true(
+    NOT EXISTS (SELECT 1 FROM public.product_inventory WHERE quantity_on_hand <> 0),
+    'existing products start at zero'
+);
+
+INSERT INTO public.products (
+    id, category_id, name, price_cents, max_per_order, is_archived
+) VALUES ('test_new_product', 'cookies', 'New Product', 100, 10, false);
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 0 FROM public.product_inventory WHERE product_id = 'test_new_product'),
+    'new products automatically receive zero inventory'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_chocolate';
+SELECT public.create_order_with_reserve(
+    'test_basic', 'track_basic',
+    '{"status":"AWAITING_PAYMENT","items":[{"id":"cakepop_chocolate","qty":2}]}'::jsonb,
+    '[{"id":"cakepop_chocolate","qty":2}]'::jsonb
+);
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
+    'stock 5 order 2 leaves 3'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 0 WHERE product_id = 'cakepop_vanilla';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_zero', 'track_zero',
+            '{"items":[{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
+            '[{"id":"cakepop_vanilla","qty":1}]'::jsonb
+        );
+        RAISE EXCEPTION 'zero stock order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'zero stock order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_invalid_quantity', 'track_invalid_quantity',
+            '{"items":[{"id":"cakepop_vanilla","qty":0}]}'::jsonb,
+            '[{"id":"cakepop_vanilla","qty":0}]'::jsonb
+        );
+        RAISE EXCEPTION 'invalid quantity order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'invalid quantity order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_unknown_product', 'track_unknown_product',
+            '{"items":[{"id":"not_a_product","qty":1}]}'::jsonb,
+            '[{"id":"not_a_product","qty":1}]'::jsonb
+        );
+        RAISE EXCEPTION 'unknown product order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'unknown product order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+
+DELETE FROM public.product_inventory WHERE product_id = 'test_new_product';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_missing', 'track_missing',
+            '{"items":[{"id":"test_new_product","qty":1}]}'::jsonb,
+            '[{"id":"test_new_product","qty":1}]'::jsonb
+        );
+        RAISE EXCEPTION 'missing inventory order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'missing inventory order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+
+UPDATE public.product_inventory SET quantity_on_hand = 2 WHERE product_id = 'cupcake_redvelvet';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_insufficient', 'track_insufficient',
+            '{"items":[{"id":"cupcake_redvelvet","qty":3}]}'::jsonb,
+            '[{"id":"cupcake_redvelvet","qty":3}]'::jsonb
+        );
+        RAISE EXCEPTION 'insufficient stock order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'insufficient stock order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cupcake_redvelvet'),
+    'insufficient reservation leaves stock unchanged'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 2 WHERE product_id = 'cakepop_chocolate';
+UPDATE public.product_inventory SET quantity_on_hand = 0 WHERE product_id = 'cakepop_vanilla';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_partial', 'track_partial',
+            '{"items":[{"id":"cakepop_chocolate","qty":1},{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
+            '[{"id":"cakepop_chocolate","qty":1},{"id":"cakepop_vanilla","qty":1}]'::jsonb
+        );
+        RAISE EXCEPTION 'partial order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'partial order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
+    'multi-item failure rolls back prior decrement'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 4 WHERE product_id = 'cakepop_chocolate';
+UPDATE public.product_inventory SET quantity_on_hand = 3 WHERE product_id = 'cakepop_vanilla';
+SELECT public.create_order_with_reserve(
+    'test_multi', 'track_multi',
+    '{"status":"AWAITING_PAYMENT","items":[{"id":"cakepop_chocolate","qty":2},{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
+    '[{"id":"cakepop_chocolate","qty":2},{"id":"cakepop_vanilla","qty":1}]'::jsonb
+);
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
+    AND (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla'),
+    'successful multi-item order decrements every product'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cupcake_chocolate';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.create_order_with_reserve(
+            'test_archived', 'track_archived',
+            '{"items":[{"id":"cupcake_chocolate","qty":1}]}'::jsonb,
+            '[{"id":"cupcake_chocolate","qty":1}]'::jsonb
+        );
+        RAISE EXCEPTION 'archived product order unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'archived product order unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+
+SELECT public.cancel_order_and_restore_inventory('test_multi');
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
+    AND (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla')
+    AND (SELECT status = 'CANCELED' AND payload->>'status' = 'CANCELED' FROM public.orders WHERE id = 'test_multi'),
+    'cancellation restores all items and both status representations'
+);
+SELECT public.cancel_order_and_restore_inventory('test_multi');
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
+    AND (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla'),
+    'repeated cancellation does not restore twice'
+);
+
+UPDATE public.orders SET status = 'COMPLETED', payload = jsonb_set(payload, '{status}', '"COMPLETED"')
+WHERE id = 'test_basic';
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.cancel_order_and_restore_inventory('test_basic');
+        RAISE EXCEPTION 'completed order cancellation unexpectedly succeeded';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'completed order cancellation unexpectedly succeeded' THEN RAISE; END IF;
+    END;
+END $$;
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
+    'completed order rejection does not restock'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 1 WHERE product_id = 'cookie_chocolatechip';
+DELETE FROM public.orders WHERE id LIKE 'race_%';


### PR DESCRIPTION
Closes #6

## Summary
- replace week/month inventory slots with one authoritative current on-hand row per product
- seed existing products at zero and automatically create zero-stock inventory for new products
- make order reservation fail closed and concurrency-safe in PostgreSQL
- restore reserved stock atomically and exactly once on cancellation
- simplify menu and admin inventory paths to current quantity semantics
- guard normal status updates against cancellation/terminal-state races

## Verification
- npm test: 69 tests passed
- npm run test:db: passed, including two concurrent orders for the last unit with exactly one success and final stock zero
- npm run lint: passed
- npx tsc --noEmit: passed
- npm run build: passed

## Migration note
Old period inventory quantities are intentionally discarded because this is prelaunch data. Existing products start with quantity_on_hand zero.