### PR TITLE
Make checkout server-authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Run migrations in order:
 4. `20260909030347_protect_public_order_tracking.sql` – separate public tracking tokens from internal order IDs
 5. `20260909040137_create_catalog.sql` – product/category catalog tables and initial seed data
 6. `20260909150000_current_product_inventory.sql` – replaces period slots with current on-hand stock and atomic cancellation restoration
+7. `20260909200000_server_authoritative_checkout.sql` – server-authoritative catalog validation, pricing, order snapshots, and private order access
+8. `20260909201000_private_flavor_requests.sql` – prevents browser roles from directly reading or modifying customer flavor requests
 
 ## Menu
 

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { handleAdminAuthFailure } from "@/lib/adminResponse";
-import type { AdminOrderRecord, OrderStatus } from "@/lib/orderTypes";
+import type { AdminOrderRecord, FulfillmentStatus, PaymentStatus } from "@/lib/orderTypes";
+import { formatCurrency } from "@/lib/menuCatalog";
 import {
 	getAllowedNextStatuses,
 	orderStatusActionLabel,
@@ -11,7 +12,7 @@ import {
 	PIPELINE_STATUSES,
 } from "@/lib/orderStatusFlow";
 
-function pipelineIndex(status: OrderStatus): number {
+function pipelineIndex(status: FulfillmentStatus): number {
 	if (status === "CANCELED") return -1;
 	return PIPELINE_STATUSES.indexOf(status);
 }
@@ -38,12 +39,12 @@ export default function AdminOrders() {
 		fetchList();
 	}, []);
 
-	async function setStatus(id: string, status: OrderStatus) {
+	async function updateOrder(id: string, change: { fulfillmentStatus: FulfillmentStatus } | { paymentStatus: PaymentStatus }) {
 		setError(null);
 		const res = await fetch(`/api/orders/${id}/status`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ status }),
+			body: JSON.stringify(change),
 		});
 		if (!res.ok) {
 			const authError = handleAdminAuthFailure(res);
@@ -62,8 +63,7 @@ export default function AdminOrders() {
 		<main className="mx-auto max-w-4xl px-4 py-6">
 			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Orders</h1>
 			<p className="mb-6 text-sm text-sage">
-				Move each order forward one step at a time: payment → kitchen → ready → picked up. Cancel anytime before
-				completion.
+				Track payment independently while moving fulfillment from received through pickup.
 			</p>
 
 			{error && (
@@ -77,7 +77,7 @@ export default function AdminOrders() {
 			) : (
 				<div className="flex flex-col gap-6">
 					{orders.map((o) => (
-						<OrderCard key={o.id} order={o} onSetStatus={setStatus} />
+						<OrderCard key={o.id} order={o} onUpdate={updateOrder} />
 					))}
 				</div>
 			)}
@@ -87,14 +87,14 @@ export default function AdminOrders() {
 
 function OrderCard({
 	order: o,
-	onSetStatus,
+	onUpdate,
 }: {
 	order: AdminOrderRecord;
-	onSetStatus: (id: string, status: OrderStatus) => void;
+	onUpdate: (id: string, change: { fulfillmentStatus: FulfillmentStatus } | { paymentStatus: PaymentStatus }) => void;
 }) {
-	const idx = pipelineIndex(o.status);
-	const nextOptions = getAllowedNextStatuses(o.status);
-	const isCanceled = o.status === "CANCELED";
+	const idx = pipelineIndex(o.fulfillmentStatus);
+	const nextOptions = getAllowedNextStatuses(o.fulfillmentStatus);
+	const isCanceled = o.fulfillmentStatus === "CANCELED";
 
 	return (
 		<div className="card-warm overflow-hidden p-4 sm:p-6">
@@ -110,12 +110,27 @@ function OrderCard({
 					</Link>
 				)}
 			</div>
+			<div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-cocoa">
+				<span>Payment: <strong>{o.payment.status}</strong> via {o.payment.method}</span>
+				{o.payment.status === "PENDING" && !isCanceled && (
+					<button type="button" className="btn-primary" onClick={() => onUpdate(o.id, { paymentStatus: "PAID" })}>Mark paid</button>
+				)}
+			</div>
+			<ul className="mt-4 space-y-1 text-sm text-cocoa">
+				{o.items.map((item) => (
+					<li key={item.productId} className="flex justify-between gap-4">
+						<span>{item.quantity} × {item.name}</span>
+						<span>{formatCurrency(item.lineTotalCents / 100)}</span>
+					</li>
+				))}
+			</ul>
+			<p className="mt-2 text-right font-semibold text-cocoa">Total: {formatCurrency(o.totals.totalCents / 100)}</p>
 
 			{isCanceled ? (
 				<p className="mt-4 rounded-lg border border-crust bg-cream/80 px-3 py-2 text-sm text-caramel">
 					<strong>Canceled</strong> — no further changes.
 				</p>
-			) : o.status === "COMPLETED" ? (
+			) : o.fulfillmentStatus === "COMPLETED" ? (
 				<p className="mt-4 rounded-lg border border-success/30 bg-success/10 px-3 py-2 text-sm text-cocoa">
 					<strong>Completed</strong> — this order is finished.
 				</p>
@@ -166,7 +181,7 @@ function OrderCard({
 							<button
 								key={s}
 								type="button"
-								onClick={() => onSetStatus(o.id, s)}
+								onClick={() => onUpdate(o.id, { fulfillmentStatus: s })}
 								className={
 									s === "CANCELED"
 										? "btn-danger"

--- a/app/api/admin/list/route.test.ts
+++ b/app/api/admin/list/route.test.ts
@@ -41,11 +41,12 @@ describe("GET /api/admin/list", () => {
 				id: "ord_internal",
 				tracking_token: "f3d4ec4e-f6c8-4dc1-b5f8-5d2fba9a8d4a",
 				created_at: "2026-09-08T20:00:00.000Z",
-				status: "PAID",
+				status: "IN_PROGRESS",
 				payload: {
 					customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Baker needs this" },
-					items: [{ id: "cake", name: "Chocolate Cake", price: 25, qty: 1 }],
-					totals: { subtotal: 25, tax: 0, total: 25 },
+					payment: { method: "zelle", status: "PENDING" },
+					items: [{ productId: "cake", name: "Chocolate Cake", unitPriceCents: 2500, quantity: 1, lineTotalCents: 2500 }],
+					totals: { subtotalCents: 2500, totalCents: 2500 },
 				},
 			}],
 			error: null,
@@ -68,6 +69,9 @@ describe("GET /api/admin/list", () => {
 			id: "ord_internal",
 			trackingToken: "f3d4ec4e-f6c8-4dc1-b5f8-5d2fba9a8d4a",
 			customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Baker needs this" },
+			fulfillmentStatus: "IN_PROGRESS",
+			payment: { method: "zelle", status: "PENDING" },
+			totals: { subtotalCents: 2500, totalCents: 2500 },
 		});
 	});
 });

--- a/app/api/admin/list/route.ts
+++ b/app/api/admin/list/route.ts
@@ -37,10 +37,11 @@ export async function GET(req: NextRequest) {
 			id: row.id,
 			trackingToken: row.tracking_token,
 			createdAt: (row.created_at ?? payload?.createdAt) as string,
-			status: row.status as OrderRecord["status"],
+			fulfillmentStatus: row.status as OrderRecord["fulfillmentStatus"],
+			payment: payload.payment as OrderRecord["payment"],
 			customer: (payload?.customer ?? { name: "", email: "" }) as OrderRecord["customer"],
 			items: (payload?.items ?? []) as OrderRecord["items"],
-			totals: (payload?.totals ?? { subtotal: 0, tax: 0, total: 0 }) as OrderRecord["totals"],
+			totals: payload.totals as OrderRecord["totals"],
 		};
 	});
 

--- a/app/api/orders/[id]/status/route.test.ts
+++ b/app/api/orders/[id]/status/route.test.ts
@@ -1,111 +1,55 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
-
-const { mockEqForSelect, mockEqForUpdate, mockExpectedStatusEq, mockFrom, mockMaybeSingleForUpdate, mockRequireAdmin, mockRpc, mockUpdate } = vi.hoisted(() => ({
-	mockEqForSelect: vi.fn(),
-	mockEqForUpdate: vi.fn(),
-	mockExpectedStatusEq: vi.fn(),
-	mockFrom: vi.fn(),
-	mockMaybeSingleForUpdate: vi.fn(),
-	mockRequireAdmin: vi.fn(),
-	mockRpc: vi.fn(),
-	mockUpdate: vi.fn(),
-}));
-
-vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
-vi.mock("@/lib/supabaseAdmin", () => ({
-	getSupabaseAdmin: () => ({ from: mockFrom, rpc: mockRpc }),
-}));
+const mocks = vi.hoisted(() => ({ from: vi.fn(), rpc: vi.fn(), update: vi.fn(), eqSelect: vi.fn(), eqUpdate: vi.fn(), eqStatus: vi.fn(), maybeSingle: vi.fn(), auth: vi.fn() }));
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mocks.auth }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ from: mocks.from, rpc: mocks.rpc }) }));
 vi.mock("@/lib/notify", () => ({ notifyStatusChange: vi.fn().mockResolvedValue(undefined) }));
-
 import { POST } from "./route";
 
-describe("POST /api/orders/[id]/status", () => {
+function request(body: unknown) { return new NextRequest("http://localhost/api/orders/ord/status", { method: "POST", body: JSON.stringify(body) }); }
+describe("POST order status", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
-		mockRequireAdmin.mockResolvedValue({
-			authorized: true,
-			admin: { id: "admin-1", email: "owner@example.com" },
-		});
-		mockEqForSelect.mockReturnValue({
-			single: vi.fn().mockResolvedValue({
-				data: {
-					status: "AWAITING_PAYMENT",
-					payload: {
-						id: "ord_internal",
-						createdAt: "2026-09-08T20:00:00.000Z",
-						status: "AWAITING_PAYMENT",
-						customer: { name: "Alice", email: "alice@example.com" },
-						items: [{ id: "cake", name: "Cake", price: 25, qty: 1 }],
-						totals: { subtotal: 25, tax: 0, total: 25 },
-					},
-				},
-				error: null,
-			}),
-		});
-		mockMaybeSingleForUpdate.mockResolvedValue({ data: { id: "ord_internal" }, error: null });
-		mockExpectedStatusEq.mockReturnValue({
-			select: vi.fn(() => ({
-				maybeSingle: mockMaybeSingleForUpdate,
-			})),
-		});
-		mockEqForUpdate.mockReturnValue({
-			eq: mockExpectedStatusEq,
-		});
-		mockRpc.mockResolvedValue({ data: { canceled: true, restored: true }, error: null });
-		mockUpdate.mockReturnValue({ eq: mockEqForUpdate });
-		mockFrom.mockReturnValue({
-			select: vi.fn(() => ({ eq: mockEqForSelect })),
-			update: mockUpdate,
-		});
+		vi.clearAllMocks(); mocks.auth.mockResolvedValue({ authorized: true });
+		mocks.eqSelect.mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { status: "RECEIVED", payload: {
+			id: "ord", createdAt: "2026-09-09", fulfillmentStatus: "RECEIVED", payment: { method: "cash", status: "PENDING" }, customer: { name: "A", email: "a@b.com" }, items: [], totals: { subtotalCents: 0, totalCents: 0 },
+		} }, error: null }) });
+		mocks.maybeSingle.mockResolvedValue({ data: { id: "ord" }, error: null });
+		mocks.eqStatus.mockReturnValue({ select: vi.fn(() => ({ maybeSingle: mocks.maybeSingle })) });
+		mocks.eqUpdate.mockReturnValue({ eq: mocks.eqStatus }); mocks.update.mockReturnValue({ eq: mocks.eqUpdate });
+		mocks.from.mockReturnValue({ select: vi.fn(() => ({ eq: mocks.eqSelect })), update: mocks.update });
+		mocks.rpc.mockResolvedValue({ data: { restored: true }, error: null });
 	});
-
-	it("cancels through the atomic restoration RPC", async () => {
-		const response = await POST(
-			new NextRequest("http://localhost/api/orders/ord_internal/status", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ status: "CANCELED" }),
-			}),
-			{ params: Promise.resolve({ id: "ord_internal" }) },
-		);
-
+	it("advances fulfillment while payment remains pending", async () => {
+		const response = await POST(request({ fulfillmentStatus: "IN_PROGRESS" }), { params: Promise.resolve({ id: "ord" }) });
 		expect(response.status).toBe(200);
-		expect(mockRpc).toHaveBeenCalledWith("cancel_order_and_restore_inventory", {
-			p_order_id: "ord_internal",
-		});
-		expect(mockUpdate).not.toHaveBeenCalled();
+		expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({ status: "IN_PROGRESS", payload: expect.objectContaining({ payment: { method: "cash", status: "PENDING" } }) }));
 	});
-
-	it("continues updating status by internal order ID", async () => {
-		const response = await POST(
-			new NextRequest("http://localhost/api/orders/ord_internal/status", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ status: "PAID" }),
-			}),
-			{ params: Promise.resolve({ id: "ord_internal" }) },
-		);
-
-		expect(response.status).toBe(200);
-		expect(mockEqForSelect).toHaveBeenCalledWith("id", "ord_internal");
-		expect(mockEqForUpdate).toHaveBeenCalledWith("id", "ord_internal");
-		expect(mockExpectedStatusEq).toHaveBeenCalledWith("status", "AWAITING_PAYMENT");
-		expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ status: "PAID" }));
+	it("marks payment paid without changing fulfillment or inventory", async () => {
+		const response = await POST(request({ paymentStatus: "PAID" }), { params: Promise.resolve({ id: "ord" }) });
+		expect(response.status).toBe(200); expect(mocks.rpc).not.toHaveBeenCalled();
+		expect(mocks.update).toHaveBeenCalledWith({ payload: expect.objectContaining({ fulfillmentStatus: "RECEIVED", payment: { method: "cash", status: "PAID" } }) });
 	});
-
-	it("does not overwrite a status changed by a concurrent request", async () => {
-		mockMaybeSingleForUpdate.mockResolvedValue({ data: null, error: null });
-
-		const response = await POST(
-			new NextRequest("http://localhost/api/orders/ord_internal/status", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ status: "PAID" }),
-			}),
-			{ params: Promise.resolve({ id: "ord_internal" }) },
-		);
-
-		expect(response.status).toBe(409);
+	it("uses only the restoration RPC for cancellation", async () => {
+		const response = await POST(request({ fulfillmentStatus: "CANCELED" }), { params: Promise.resolve({ id: "ord" }) });
+		expect(response.status).toBe(200); expect(mocks.rpc).toHaveBeenCalledWith("cancel_order_and_restore_inventory", { p_order_id: "ord" });
+		expect(mocks.update).not.toHaveBeenCalled();
+	});
+	it("returns a safe client error for malformed JSON", async () => {
+		const malformed = new NextRequest("http://localhost/api/orders/ord/status", { method: "POST", body: "{" });
+		const response = await POST(malformed, { params: Promise.resolve({ id: "ord" }) });
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Invalid JSON body" });
+		expect(mocks.from).not.toHaveBeenCalled();
+	});
+	it.each(["COMPLETED", "CANCELED"])("rejects payment changes after %s", async (status) => {
+		mocks.eqSelect.mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { status, payload: {
+			id: "ord", createdAt: "2026-09-09", fulfillmentStatus: status,
+			payment: { method: "cash", status: "PENDING" }, customer: { name: "A", email: "a@b.com" },
+			items: [], totals: { subtotalCents: 0, totalCents: 0 },
+		} }, error: null }) });
+		const response = await POST(request({ paymentStatus: "PAID" }), { params: Promise.resolve({ id: "ord" }) });
+		expect(response.status).toBe(400);
+		expect(mocks.update).not.toHaveBeenCalled();
+		expect(mocks.rpc).not.toHaveBeenCalled();
 	});
 });

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -1,64 +1,66 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/adminAuth";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import type { OrderRecord, OrderStatus } from "@/lib/orderTypes";
+import type { FulfillmentStatus, OrderRecord, PaymentStatus } from "@/lib/orderTypes";
 import { notifyStatusChange } from "@/lib/notify";
 import { isValidOrderStatusTransition } from "@/lib/orderStatusFlow";
 
-export async function POST(
-	req: NextRequest,
-	context: { params: Promise<{ id: string }> }
-) {
+export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
 	const authorization = await requireAdmin();
 	if (!authorization.authorized) return authorization.response;
 
 	const { id } = await context.params;
-	const { status } = (await req.json()) as { status: OrderStatus };
-
-	const supabase = getSupabaseAdmin();
-	const { data, error } = await supabase
-		.from("orders")
-		.select("status, payload")
-		.eq("id", id)
-		.single();
-
-	if (error || !data) return new NextResponse("Not found", { status: 404 });
-
-	const previous = { ...(data.payload as OrderRecord), status: data.status as OrderStatus };
-	if (previous.status !== status && !isValidOrderStatusTransition(previous.status, status)) {
-		return NextResponse.json(
-			{
-				error: `Invalid status change: ${previous.status} → ${status}. Follow the order workflow (e.g. paid before in progress, in progress before completed).`,
-			},
-			{ status: 400 }
-		);
+	let rawBody: unknown;
+	try {
+		rawBody = await req.json();
+	} catch {
+		return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+	}
+	if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+		return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+	}
+	const body = rawBody as { fulfillmentStatus?: FulfillmentStatus; paymentStatus?: PaymentStatus };
+	const fulfillmentStatus = body.fulfillmentStatus;
+	const paymentStatus = body.paymentStatus;
+	if ((fulfillmentStatus ? 1 : 0) + (paymentStatus ? 1 : 0) !== 1) {
+		return NextResponse.json({ error: "Submit exactly one fulfillment or payment status" }, { status: 400 });
+	}
+	if (paymentStatus && paymentStatus !== "PENDING" && paymentStatus !== "PAID") {
+		return NextResponse.json({ error: "Invalid payment status" }, { status: 400 });
 	}
 
-	const updated: OrderRecord = { ...previous, status };
-	if (status === "CANCELED") {
-		const { data: cancellation, error: cancelError } = await supabase.rpc("cancel_order_and_restore_inventory", {
-			p_order_id: id,
-		});
-		if (cancelError) {
-			return NextResponse.json({ error: cancelError.message }, { status: 400 });
+	const supabase = getSupabaseAdmin();
+	const { data, error } = await supabase.from("orders").select("status, payload").eq("id", id).single();
+	if (error || !data) return new NextResponse("Not found", { status: 404 });
+
+	const previous = { ...(data.payload as OrderRecord), fulfillmentStatus: data.status as FulfillmentStatus };
+	if (paymentStatus) {
+		if (previous.fulfillmentStatus === "COMPLETED" || previous.fulfillmentStatus === "CANCELED") {
+			return NextResponse.json({ error: "Payment cannot be changed after fulfillment is closed" }, { status: 400 });
 		}
+		const updated: OrderRecord = { ...previous, payment: { ...previous.payment, status: paymentStatus } };
+		const { data: changed, error: updateError } = await supabase.from("orders").update({ payload: updated })
+			.eq("id", id).eq("status", previous.fulfillmentStatus).select("id").maybeSingle();
+		if (updateError) return NextResponse.json({ error: "Could not update payment status" }, { status: 400 });
+		if (!changed) return NextResponse.json({ error: "Order changed; refresh and try again" }, { status: 409 });
+		return NextResponse.json({ ok: true });
+	}
+
+	if (!fulfillmentStatus || (previous.fulfillmentStatus !== fulfillmentStatus && !isValidOrderStatusTransition(previous.fulfillmentStatus, fulfillmentStatus))) {
+		return NextResponse.json({ error: "Invalid fulfillment status change" }, { status: 400 });
+	}
+	const updated: OrderRecord = { ...previous, fulfillmentStatus };
+	if (fulfillmentStatus === "CANCELED") {
+		const { data: cancellation, error: cancelError } = await supabase.rpc("cancel_order_and_restore_inventory", { p_order_id: id });
+		if (cancelError) { console.error("[orders] cancellation failed", cancelError); return NextResponse.json({ error: "Could not cancel order" }, { status: 400 }); }
 		if (cancellation?.restored !== false) notifyStatusChange(updated).catch(console.warn);
 		return NextResponse.json({ ok: true });
 	}
 
-	const { data: changed, error: upErr } = await supabase
-		.from("orders")
-		.update({ status, payload: updated })
-		.eq("id", id)
-		.eq("status", previous.status)
-		.select("id")
-		.maybeSingle();
-
-	if (upErr) return NextResponse.json({ error: upErr.message }, { status: 400 });
-	if (!changed) {
-		return NextResponse.json({ error: "Order status changed; refresh and try again" }, { status: 409 });
-	}
-
+	const { data: changed, error: updateError } = await supabase.from("orders").update({ status: fulfillmentStatus, payload: updated })
+		.eq("id", id).eq("status", previous.fulfillmentStatus).select("id").maybeSingle();
+	if (updateError) return NextResponse.json({ error: "Could not update fulfillment status" }, { status: 400 });
+	if (!changed) return NextResponse.json({ error: "Order changed; refresh and try again" }, { status: 409 });
 	notifyStatusChange(updated).catch(console.warn);
 	return NextResponse.json({ ok: true });
 }

--- a/app/api/orders/route.test.ts
+++ b/app/api/orders/route.test.ts
@@ -1,57 +1,66 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { mockRpc } = vi.hoisted(() => ({ mockRpc: vi.fn() }));
-
-vi.mock("@/lib/supabaseAdmin", () => ({
-	getSupabaseAdmin: () => ({ rpc: mockRpc }),
-}));
-vi.mock("@/lib/notify", () => ({ notifyNewOrder: vi.fn().mockResolvedValue(undefined) }));
+const { mockNotify, mockRpc } = vi.hoisted(() => ({ mockNotify: vi.fn(), mockRpc: vi.fn() }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ rpc: mockRpc }) }));
+vi.mock("@/lib/notify", () => ({ notifyNewOrder: mockNotify }));
 vi.mock("@/lib/rateLimit", () => ({ checkRateLimit: () => null }));
-
 import { POST } from "./route";
 
-const payload = {
-	customer: { name: "Alice Baker", email: "alice@example.com", paymentMethod: "cash" },
-	items: [{ id: "cake", name: "Chocolate Cake", price: 25, qty: 1 }],
-	totals: { subtotal: 25, tax: 0, total: 25 },
+const authoritativeOrder = {
+	id: "ord_server", createdAt: "2026-09-09T20:00:00.000Z", fulfillmentStatus: "RECEIVED",
+	payment: { method: "cash", status: "PENDING" },
+	customer: { name: "Alice Baker", email: "alice@example.com" },
+	items: [{ productId: "cake", name: "Real Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
+	totals: { subtotalCents: 5000, totalCents: 5000 },
 };
 
-function orderRequest() {
-	return new NextRequest("http://localhost/api/orders", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(payload),
-	});
+function request(body: unknown) {
+	return new NextRequest("http://localhost/api/orders", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
 }
+
+const trustedRequest = {
+	customer: { name: "Alice Baker", email: "alice@example.com" },
+	payment: { method: "cash" }, items: [{ productId: "cake", quantity: 2 }],
+};
 
 describe("POST /api/orders", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockRpc.mockResolvedValue({ error: null });
+		mockNotify.mockResolvedValue(undefined);
+		mockRpc.mockResolvedValue({ data: { id: "ord_server", order: authoritativeOrder }, error: null });
 	});
 
-	it("always creates through the atomic inventory RPC", async () => {
-		const response = await POST(orderRequest());
-		const body = await response.json();
-		const rpcArgs = mockRpc.mock.calls[0][1];
-
-		expect(response.status).toBe(201);
-		expect(mockRpc).toHaveBeenCalledTimes(1);
-		expect(mockRpc).toHaveBeenCalledWith("create_order_with_reserve", expect.objectContaining({
-			p_order_id: expect.stringMatching(/^ord_/),
-			p_tracking_token: body.trackingToken,
-			p_items: [{ id: "cake", qty: 1 }],
+	it("passes only trusted input to the atomic authoritative RPC and returns its result", async () => {
+		const response = await POST(request({ ...trustedRequest,
+			items: [{ productId: "cake", quantity: 2, name: "Fake", price: 0 }], totals: { subtotal: 0, total: 0 },
 		}));
-		expect(rpcArgs.p_tracking_token).not.toBe(rpcArgs.p_order_id);
+		const body = await response.json();
+		const args = mockRpc.mock.calls[0][1];
+		expect(response.status).toBe(201);
+		expect(mockRpc).toHaveBeenCalledWith("create_authoritative_order", expect.any(Object));
+		expect(args.p_customer).toEqual(trustedRequest.customer);
+		expect(args.p_payment).toEqual({ method: "cash" });
+		expect(args.p_items).toEqual([{ productId: "cake", quantity: 2 }]);
+		expect(JSON.stringify(args)).not.toContain("Fake");
+		expect(body).toMatchObject({ trackingToken: expect.any(String), order: authoritativeOrder });
+		expect(mockNotify).toHaveBeenCalledWith(authoritativeOrder);
 	});
 
-	it("fails closed when the reservation RPC rejects the order", async () => {
-		mockRpc.mockResolvedValue({ data: null, error: { message: "Item cake: inventory state is missing" } });
+	it.each([["INVALID_PRODUCT", 400], ["PRODUCT_UNAVAILABLE", 409], ["MAX_QUANTITY_EXCEEDED", 400], ["OUT_OF_STOCK", 409]])(
+		"maps %s without exposing database details", async (code, status) => {
+			mockRpc.mockResolvedValue({ data: null, error: { message: `${code}: secret table detail` } });
+			const response = await POST(request(trustedRequest));
+			const body = await response.json();
+			expect(response.status).toBe(status);
+			expect(body).toEqual(expect.objectContaining({ code }));
+			expect(JSON.stringify(body)).not.toContain("secret");
+		},
+	);
 
-		const response = await POST(orderRequest());
-
-		expect(response.status).toBe(400);
-		expect(await response.json()).toEqual({ error: "Item cake: inventory state is missing" });
+	it("uses a generic safe error for unexpected database failures", async () => {
+		mockRpc.mockResolvedValue({ data: null, error: { message: "relation products leaked internal detail" } });
+		const response = await POST(request(trustedRequest));
+		expect(await response.json()).toEqual({ code: "ORDER_FAILED", error: "We could not place your order. Please try again." });
 	});
 });

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -6,53 +6,43 @@ import { checkRateLimit } from "@/lib/rateLimit";
 import { validateOrderPayload } from "@/lib/orderValidation";
 import { createTrackingToken } from "@/lib/orderTracking";
 
+const EXPECTED_ERRORS = {
+	INVALID_PRODUCT: { status: 400, error: "One or more products are invalid." },
+	PRODUCT_UNAVAILABLE: { status: 409, error: "One or more products are no longer available." },
+	MAX_QUANTITY_EXCEEDED: { status: 400, error: "A requested quantity exceeds the per-order limit." },
+	OUT_OF_STOCK: { status: 409, error: "One or more products do not have enough stock." },
+	INVALID_QUANTITY: { status: 400, error: "Quantities must be positive whole numbers." },
+	INVALID_PAYMENT_METHOD: { status: 400, error: "Choose a valid payment method." },
+} as const;
+
+function databaseError(message?: string) {
+	const code = Object.keys(EXPECTED_ERRORS).find((candidate) => message?.startsWith(candidate)) as keyof typeof EXPECTED_ERRORS | undefined;
+	if (!code) return NextResponse.json({ code: "ORDER_FAILED", error: "We could not place your order. Please try again." }, { status: 500 });
+	return NextResponse.json({ code, error: EXPECTED_ERRORS[code].error }, { status: EXPECTED_ERRORS[code].status });
+}
+
 export async function POST(req: NextRequest) {
 	const rateLimitResponse = checkRateLimit(req);
 	if (rateLimitResponse) return rateLimitResponse;
-
 	try {
 		let body: unknown;
-		try {
-			body = await req.json();
-		} catch {
-			return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-		}
-
+		try { body = await req.json(); } catch { return NextResponse.json({ code: "INVALID_ORDER", error: "Invalid JSON body" }, { status: 400 }); }
 		const validation = validateOrderPayload(body);
-		if (!validation.ok) {
-			return NextResponse.json({ error: validation.error }, { status: 400 });
-		}
+		if (!validation.ok) return NextResponse.json({ code: validation.code, error: validation.error }, { status: 400 });
 
-		const { data: orderData } = validation;
-		const id = `ord_${Date.now().toString(36)}`;
+		const id = `ord_${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
 		const trackingToken = createTrackingToken();
-		const supabase = getSupabaseAdmin();
-
-		const order: OrderRecord = {
-			id,
-			createdAt: new Date().toISOString(),
-			status: "AWAITING_PAYMENT",
-			customer: orderData.customer,
-			items: orderData.items,
-			totals: orderData.totals,
-		};
-
-		const itemsPayload = orderData.items.map((i) => ({ id: i.id, qty: i.qty }));
-		const { error } = await supabase.rpc("create_order_with_reserve", {
-			p_order_id: id,
-			p_tracking_token: trackingToken,
-			p_payload: order,
-			p_items: itemsPayload,
+		const { data, error } = await getSupabaseAdmin().rpc("create_authoritative_order", {
+			p_order_id: id, p_tracking_token: trackingToken,
+			p_customer: validation.data.customer, p_payment: validation.data.payment, p_items: validation.data.items,
 		});
-
-		if (error) {
-			return NextResponse.json({ error: error.message ?? "Order failed" }, { status: 400 });
-		}
-
+		if (error) { console.error("[orders] authoritative order failed", error); return databaseError(error.message); }
+		const order = data?.order as OrderRecord | undefined;
+		if (!order) { console.error("[orders] authoritative order returned no order", data); return databaseError(); }
 		notifyNewOrder(order).catch(console.warn);
-		return NextResponse.json({ trackingToken }, { status: 201 });
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	} catch (e: any) {
-		return NextResponse.json({ error: e.message ?? "failed" }, { status: 400 });
+		return NextResponse.json({ trackingToken, order }, { status: 201 });
+	} catch (error) {
+		console.error("[orders] unexpected failure", error);
+		return databaseError();
 	}
 }

--- a/app/api/orders/track/[token]/route.test.ts
+++ b/app/api/orders/track/[token]/route.test.ts
@@ -1,92 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
-
-const { mockEq, mockFrom, mockSelect, mockSingle } = vi.hoisted(() => {
-	const mockSingle = vi.fn();
-	const mockEq = vi.fn(() => ({ single: mockSingle }));
-	const mockSelect = vi.fn(() => ({ eq: mockEq }));
-	const mockFrom = vi.fn(() => ({ select: mockSelect }));
-	return { mockEq, mockFrom, mockSelect, mockSingle };
-});
-
-vi.mock("@/lib/supabaseAdmin", () => ({
-	getSupabaseAdmin: () => ({ from: mockFrom }),
-}));
-
+const { mockEq, mockFrom } = vi.hoisted(() => ({ mockEq: vi.fn(), mockFrom: vi.fn() }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ from: mockFrom }) }));
 import { GET } from "./route";
 
 const token = "f3d4ec4e-f6c8-4dc1-b5f8-5d2fba9a8d4a";
-const privatePayload = {
-	id: "ord_internal",
-	status: "AWAITING_PAYMENT",
-	createdAt: "2026-09-08T20:00:00.000Z",
-	customer: {
-		name: "Alice Baker",
-		email: "alice@example.com",
-		phone: "555-0100",
-		notes: "Private note",
-		paymentMethod: "venmo",
-		venmoUser: "@alice",
-		venmoNote: "private payment metadata",
-	},
-	items: [{ id: "cake", name: "Chocolate Cake", price: 25, qty: 2 }],
-	totals: { subtotal: 50, tax: 4, total: 54 },
-};
-
-function request(value: string) {
-	return GET(
-		new NextRequest(`http://localhost/api/orders/track/${value}`),
-		{ params: Promise.resolve({ token: value }) },
-	);
-}
-
 describe("GET /api/orders/track/[token]", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockEq.mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { status: "RECEIVED", payload: {
+			payment: { method: "cash", status: "PENDING" },
+			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 1, lineTotalCents: 2500 }],
+			totals: { subtotalCents: 2500, totalCents: 2500 }, customer: { name: "Private", email: "private@example.com" },
+		} }, error: null }) });
+		mockFrom.mockReturnValue({ select: vi.fn(() => ({ eq: mockEq })) });
 	});
-
-	it("returns the customer-safe order using the tracking token and database status", async () => {
-		mockSingle.mockResolvedValue({
-			data: { status: "READY_FOR_PICKUP", payload: privatePayload },
-			error: null,
-		});
-
-		const response = await request(token);
-
+	it("returns protected authoritative purchase-time information", async () => {
+		const response = await GET(new NextRequest(`http://localhost/api/orders/track/${token}`), { params: Promise.resolve({ token }) });
+		const body = await response.json();
 		expect(response.status).toBe(200);
-		expect(response.headers.get("cache-control")).toBe("no-store");
-		expect(mockFrom).toHaveBeenCalledWith("orders");
-		expect(mockSelect).toHaveBeenCalledWith("status, payload");
-		expect(mockEq).toHaveBeenCalledWith("tracking_token", token);
-		expect(await response.json()).toEqual({
-			status: "READY_FOR_PICKUP",
-			items: [{ name: "Chocolate Cake", price: 25, qty: 2 }],
-			total: 54,
-		});
+		expect(body).toMatchObject({ fulfillmentStatus: "RECEIVED", payment: { method: "cash", status: "PENDING" }, totals: { totalCents: 2500 } });
+		expect(body).not.toHaveProperty("customer");
 	});
-
-	it("returns 404 for an unknown random token", async () => {
-		mockSingle.mockResolvedValue({ data: null, error: { message: "not found" } });
-
-		const response = await request(token);
-
-		expect(response.status).toBe(404);
-		expect(await response.text()).toBe("Not Found");
-	});
-
-	it("returns the same 404 for an internal order ID without querying it", async () => {
-		const response = await request("ord_mxyz123");
-
-		expect(response.status).toBe(404);
-		expect(await response.text()).toBe("Not Found");
-		expect(mockFrom).not.toHaveBeenCalled();
-	});
-
-	it("handles malformed tracking values with the same safe 404", async () => {
-		const response = await request("not-a-token");
-
-		expect(response.status).toBe(404);
-		expect(await response.text()).toBe("Not Found");
-		expect(mockFrom).not.toHaveBeenCalled();
+	it("rejects invalid tokens before querying", async () => {
+		const response = await GET(new NextRequest("http://localhost/api/orders/track/bad"), { params: Promise.resolve({ token: "bad" }) });
+		expect(response.status).toBe(404); expect(mockFrom).not.toHaveBeenCalled();
 	});
 });

--- a/app/api/orders/track/[token]/route.ts
+++ b/app/api/orders/track/[token]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import type { OrderRecord, OrderStatus } from "@/lib/orderTypes";
+import type { FulfillmentStatus, OrderRecord } from "@/lib/orderTypes";
 import { isValidTrackingToken, toPublicOrderTracking } from "@/lib/orderTracking";
 
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
@@ -25,7 +25,7 @@ export async function GET(
 
 	if (error || !data) return notFound();
 
-	const payload = data.payload as Pick<OrderRecord, "items" | "totals">;
-	const order = toPublicOrderTracking(data.status as OrderStatus, payload);
+	const payload = data.payload as Pick<OrderRecord, "payment" | "items" | "totals">;
+	const order = toPublicOrderTracking(data.status as FulfillmentStatus, payload);
 	return NextResponse.json(order, { headers: NO_STORE_HEADERS });
 }

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useCart } from "@/components/cart/useCart";
 import OrderSummary from "@/components/checkout/OrderSummary";
 import CheckoutForm, { CheckoutData } from "@/components/checkout/paymentTiles/CheckoutForm";
 import VenmoTile from "@/components/checkout/paymentTiles/VenmoTile";
+import type { PaymentMethod } from "@/lib/orderTypes";
 
 export default function CheckoutPage() {
 	const router = useRouter();
 	const { items, clearCart, hydrated } = useCart();
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [paymentMethod, setPaymentMethod] = useState<"venmo" | "cash">("venmo");
+	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("venmo");
 	const orderPlacedRef = useRef(false);
 
 	useEffect(() => {
@@ -21,16 +22,14 @@ export default function CheckoutPage() {
 		}
 	}, [hydrated, items.length, router]);
 
-	const subtotal = useMemo(() => items.reduce((s, i) => s + i.price * i.qty, 0), [items]);
-
 	async function submit(data: CheckoutData) {
 		if (!items.length) return;
 		setSubmitting(true);
 		setError(null);
 		const payload = {
-			customer: data,
-			items: items.map((i) => ({ id: i.id, name: i.name, price: i.price, qty: i.qty })),
-			totals: { subtotal, tax: 0, total: subtotal },
+			customer: { name: data.name, email: data.email, phone: data.phone, notes: data.notes },
+			payment: { method: data.paymentMethod, venmoUser: data.venmoUser, note: data.paymentNote },
+			items: items.map((item) => ({ productId: item.id, quantity: item.qty })),
 		};
 		const res = await fetch("/api/orders", {
 			method: "POST",
@@ -84,7 +83,9 @@ export default function CheckoutPage() {
 					<p className="mt-4 text-sm text-sage">
 						{paymentMethod === "venmo"
 							? "After you pay via Venmo, we'll confirm and update your order status."
-							: "Pay with cash when you pick up your order."}
+							: paymentMethod === "zelle"
+								? "Send payment via Zelle. The baker will verify it manually."
+								: "Pay with cash at pickup. Your order can be prepared while payment is pending."}
 					</p>
 					<button
 						type="submit"

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import type { PublicOrderTracking } from "@/lib/orderTypes";
 import { formatCurrency } from "@/lib/menuCatalog";
@@ -18,7 +18,7 @@ export default function OrderPage() {
 				setLoadError(null);
 				const o: PublicOrderTracking = await res.json();
 				setOrder(o);
-				if (["READY_FOR_PICKUP", "COMPLETED", "CANCELED"].includes(o.status)) return;
+				if (["READY_FOR_PICKUP", "COMPLETED", "CANCELED"].includes(o.fulfillmentStatus)) return;
 			} else if (res.status === 404 || res.status === 503) {
 				const body = await res.json().catch(() => ({}));
 				setLoadError(
@@ -33,7 +33,6 @@ export default function OrderPage() {
 		return () => clearTimeout(t);
 	}, [token]);
 
-	const total = useMemo(() => order?.total ?? 0, [order]);
 	if (loadError) {
 		return (
 			<main className="mx-auto max-w-2xl px-4 py-6 sm:px-6">
@@ -50,7 +49,7 @@ export default function OrderPage() {
 			</main>
 		);
 
-	const isAwaitingPayment = order.status === "AWAITING_PAYMENT";
+	const isAwaitingPayment = order.payment.status === "PENDING";
 
 	return (
 		<main className="mx-auto max-w-2xl px-4 py-6 sm:px-6">
@@ -59,33 +58,35 @@ export default function OrderPage() {
 				<div className="mb-6 rounded-lg border border-crust bg-wheat p-4">
 					<p className="font-semibold text-cocoa">Order placed!</p>
 					<p className="mt-2 text-sm text-cocoa/80">
-						Pay via Venmo and we&apos;ll confirm your order. You can check back here for status updates.
+						Payment is pending. The baker will update it after manually confirming {order.payment.method} payment.
 					</p>
 				</div>
 			)}
 			<div className="mb-6 rounded-lg border border-crust bg-wheat px-4 py-3">
 				<span className="text-sage">Status:</span>{" "}
-				<strong className="text-cocoa">{order.status.replaceAll("_", " ")}</strong>
+				<strong className="text-cocoa">{order.fulfillmentStatus.replaceAll("_", " ")}</strong>
+				<span className="ml-4 text-sage">Payment:</span>{" "}
+				<strong className="text-cocoa">{order.payment.status}</strong>
 			</div>
 
 			<section>
 				{order.items.map((i, index) => (
 					<div
-						key={`${i.name}-${i.price}-${index}`}
+						key={`${i.productId}-${index}`}
 						className="mb-2 grid grid-cols-[1fr_auto] items-center gap-4 rounded-lg border border-crust bg-wheat p-4"
 					>
 						<div>
 							<div className="font-semibold text-cocoa">{i.name}</div>
 							<div className="text-xs text-sage">
-								{formatCurrency(i.price)} × {i.qty}
+								{formatCurrency(i.unitPriceCents / 100)} × {i.quantity}
 							</div>
 						</div>
-						<div className="text-right font-semibold text-cocoa">{formatCurrency(i.price * i.qty)}</div>
+						<div className="text-right font-semibold text-cocoa">{formatCurrency(i.lineTotalCents / 100)}</div>
 					</div>
 				))}
 				<div className="mt-4 flex justify-between font-semibold text-cocoa">
 					<span className="text-sage">Total</span>
-					<span>{formatCurrency(total)}</span>
+					<span>{formatCurrency(order.totals.totalCents / 100)}</span>
 				</div>
 			</section>
 		</main>

--- a/components/cart/CartSheet.tsx
+++ b/components/cart/CartSheet.tsx
@@ -118,10 +118,7 @@ export default function CartSheet({ open, onClose, onCheckout }: CartSheetProps)
 							<span className="text-sm text-sage">Subtotal</span>
 							<span className="font-semibold">{formatCurrency(subtotal)}</span>
 						</div>
-						<div className="flex justify-between">
-							<span className="text-sm text-sage">Tax</span>
-							<span className="text-sm text-sage">Calculated at checkout</span>
-						</div>
+						<p className="text-xs text-sage">Final pricing is confirmed from the current catalog when the order is placed.</p>
 						<div className="flex justify-between font-bold">
 							<span>Total</span>
 							<span className="text-lg">{formatCurrency(subtotal)}</span>

--- a/components/checkout/OrderSummary.tsx
+++ b/components/checkout/OrderSummary.tsx
@@ -36,10 +36,7 @@ export default function OrderSummary() {
 				<span className="text-sage">Subtotal</span>
 				<span className="text-cocoa">{formatCurrency(subtotal)}</span>
 			</div>
-			<div className="mt-2 flex justify-between">
-				<span className="text-sage">Tax</span>
-				<span className="text-sage">Calculated at pickup</span>
-			</div>
+			<p className="mt-2 text-xs text-sage">Final pricing is confirmed from the current catalog when you place the order.</p>
 			<div className="mt-4 flex justify-between font-bold text-cocoa">
 				<span>Total</span>
 				<span>{formatCurrency(subtotal)}</span>

--- a/components/checkout/paymentTiles/CheckoutForm.tsx
+++ b/components/checkout/paymentTiles/CheckoutForm.tsx
@@ -1,19 +1,20 @@
 "use client";
 import { useState, useMemo, useEffect } from "react";
+import type { PaymentMethod } from "@/lib/orderTypes";
 
 export type CheckoutData = {
 	name: string;
 	email: string;
 	phone?: string;
 	notes?: string;
-	paymentMethod: "venmo" | "cash";
+	paymentMethod: PaymentMethod;
 	venmoUser?: string;
-	venmoNote?: string;
+	paymentNote?: string;
 };
 
 type Props = {
 	onSubmit: (data: CheckoutData) => void;
-	onPaymentMethodChange?: (method: "venmo" | "cash") => void;
+	onPaymentMethodChange?: (method: PaymentMethod) => void;
 };
 
 export default function CheckoutForm({ onSubmit, onPaymentMethodChange }: Props) {
@@ -30,9 +31,7 @@ export default function CheckoutForm({ onSubmit, onPaymentMethodChange }: Props)
 	const isValid = useMemo(() => {
 		const contactValid =
 			form.name.trim().length > 1 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim());
-		const venmoValid =
-			form.paymentMethod === "cash" ||
-			(form.venmoUser?.trim() ?? "").length > 0;
+		const venmoValid = form.paymentMethod !== "venmo" || (form.venmoUser?.trim() ?? "").length > 0;
 		return contactValid && venmoValid;
 	}, [form]);
 
@@ -108,6 +107,11 @@ export default function CheckoutForm({ onSubmit, onPaymentMethodChange }: Props)
 						/>
 						<span className="text-cocoa">Cash</span>
 					</label>
+					<label className="flex cursor-pointer items-center gap-2">
+						<input type="radio" name="paymentMethod" value="zelle" checked={form.paymentMethod === "zelle"}
+							onChange={() => setForm((s) => ({ ...s, paymentMethod: "zelle" }))} className="h-4 w-4 accent-honey" />
+						<span className="text-cocoa">Zelle</span>
+					</label>
 				</div>
 			</fieldset>
 
@@ -125,13 +129,19 @@ export default function CheckoutForm({ onSubmit, onPaymentMethodChange }: Props)
 					<label>
 						<div className="mb-1.5 text-sm font-medium text-cocoa">Payment note (optional)</div>
 						<input
-							value={form.venmoNote ?? ""}
-							onChange={(e) => setForm((s) => ({ ...s, venmoNote: e.target.value }))}
+							value={form.paymentNote ?? ""}
+							onChange={(e) => setForm((s) => ({ ...s, paymentNote: e.target.value }))}
 							placeholder="Order # or item description"
 							className="input-base"
 						/>
 					</label>
 				</div>
+			)}
+			{form.paymentMethod === "zelle" && (
+				<label className="rounded-lg border border-crust bg-wheat/50 p-4">
+					<div className="mb-1.5 text-sm font-medium text-cocoa">Payment note/reference (optional)</div>
+					<input value={form.paymentNote ?? ""} onChange={(e) => setForm((s) => ({ ...s, paymentNote: e.target.value }))} className="input-base" />
+				</label>
 			)}
 		</form>
 	);

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -6,5 +6,5 @@ export async function notifyNewOrder(order: OrderRecord) {
 }
 
 export async function notifyStatusChange(order: OrderRecord) {
-	console.log("[notify] status change", order.id, order.status);
+	console.log("[notify] status change", order.id, order.fulfillmentStatus);
 }

--- a/lib/orderStatusFlow.test.ts
+++ b/lib/orderStatusFlow.test.ts
@@ -1,49 +1,21 @@
-import { describe, it, expect } from "vitest";
-import {
-	getAllowedNextStatuses,
-	isValidOrderStatusTransition,
-	PIPELINE_STATUSES,
-} from "./orderStatusFlow";
-import type { OrderStatus } from "./orderTypes";
+import { describe, expect, it } from "vitest";
+import { getAllowedNextStatuses, isValidOrderStatusTransition, PIPELINE_STATUSES } from "./orderStatusFlow";
 
-describe("orderStatusFlow", () => {
-	it("does not allow skipping pipeline steps", () => {
-		expect(isValidOrderStatusTransition("AWAITING_PAYMENT", "IN_PROGRESS")).toBe(false);
-		expect(isValidOrderStatusTransition("PAID", "COMPLETED")).toBe(false);
-		expect(isValidOrderStatusTransition("PAID", "READY_FOR_PICKUP")).toBe(false);
-	});
-
-	it("allows linear progression", () => {
-		expect(isValidOrderStatusTransition("AWAITING_PAYMENT", "PAID")).toBe(true);
-		expect(isValidOrderStatusTransition("PAID", "IN_PROGRESS")).toBe(true);
+describe("fulfillment status flow", () => {
+	it("advances without depending on payment state", () => {
+		expect(isValidOrderStatusTransition("RECEIVED", "IN_PROGRESS")).toBe(true);
 		expect(isValidOrderStatusTransition("IN_PROGRESS", "READY_FOR_PICKUP")).toBe(true);
 		expect(isValidOrderStatusTransition("READY_FOR_PICKUP", "COMPLETED")).toBe(true);
 	});
-
-	it("allows cancel from non-terminal states", () => {
-		const cancellable: OrderStatus[] = [
-			"AWAITING_PAYMENT",
-			"PAID",
-			"IN_PROGRESS",
-			"READY_FOR_PICKUP",
-		];
-		for (const s of cancellable) {
-			expect(getAllowedNextStatuses(s)).toContain("CANCELED");
-		}
+	it("prevents skipped steps and permits cancellation before completion", () => {
+		expect(isValidOrderStatusTransition("RECEIVED", "READY_FOR_PICKUP")).toBe(false);
+	for (const status of ["RECEIVED", "IN_PROGRESS", "READY_FOR_PICKUP"] as const) expect(getAllowedNextStatuses(status)).toContain("CANCELED");
 	});
-
-	it("has no transitions from terminal states", () => {
+	it("keeps terminal states terminal", () => {
 		expect(getAllowedNextStatuses("COMPLETED")).toEqual([]);
 		expect(getAllowedNextStatuses("CANCELED")).toEqual([]);
 	});
-
-	it("pipeline list matches expected length and order", () => {
-		expect(PIPELINE_STATUSES).toEqual([
-			"AWAITING_PAYMENT",
-			"PAID",
-			"IN_PROGRESS",
-			"READY_FOR_PICKUP",
-			"COMPLETED",
-		]);
+	it("contains fulfillment states only", () => {
+		expect(PIPELINE_STATUSES).toEqual(["RECEIVED", "IN_PROGRESS", "READY_FOR_PICKUP", "COMPLETED"]);
 	});
 });

--- a/lib/orderStatusFlow.ts
+++ b/lib/orderStatusFlow.ts
@@ -1,67 +1,19 @@
-import type { OrderStatus } from "./orderTypes";
+import type { FulfillmentStatus } from "./orderTypes";
 
-/**
- * Allowed one-step transitions for the bakery order workflow.
- * Terminal states (COMPLETED, CANCELED) cannot be changed through this flow.
- */
-const ALLOWED: Record<OrderStatus, readonly OrderStatus[]> = {
-	AWAITING_PAYMENT: ["PAID", "CANCELED"],
-	PAID: ["IN_PROGRESS", "CANCELED"],
+const ALLOWED: Record<FulfillmentStatus, readonly FulfillmentStatus[]> = {
+	RECEIVED: ["IN_PROGRESS", "CANCELED"],
 	IN_PROGRESS: ["READY_FOR_PICKUP", "CANCELED"],
 	READY_FOR_PICKUP: ["COMPLETED", "CANCELED"],
 	COMPLETED: [],
 	CANCELED: [],
 };
 
-/** Main line statuses shown in the admin pipeline (excludes CANCELED). */
-export const PIPELINE_STATUSES: OrderStatus[] = [
-	"AWAITING_PAYMENT",
-	"PAID",
-	"IN_PROGRESS",
-	"READY_FOR_PICKUP",
-	"COMPLETED",
-];
-
-export function getAllowedNextStatuses(current: OrderStatus): OrderStatus[] {
-	return [...(ALLOWED[current] ?? [])];
+export const PIPELINE_STATUSES: FulfillmentStatus[] = ["RECEIVED", "IN_PROGRESS", "READY_FOR_PICKUP", "COMPLETED"];
+export function getAllowedNextStatuses(current: FulfillmentStatus): FulfillmentStatus[] { return [...(ALLOWED[current] ?? [])]; }
+export function isValidOrderStatusTransition(from: FulfillmentStatus, to: FulfillmentStatus): boolean { return getAllowedNextStatuses(from).includes(to); }
+export function orderStatusActionLabel(status: FulfillmentStatus): string {
+	return ({ RECEIVED: "Received", IN_PROGRESS: "In progress", READY_FOR_PICKUP: "Ready for pickup", COMPLETED: "Completed", CANCELED: "Canceled" })[status];
 }
-
-export function isValidOrderStatusTransition(from: OrderStatus, to: OrderStatus): boolean {
-	return getAllowedNextStatuses(from).includes(to);
-}
-
-/** Short label for buttons and chips. */
-export function orderStatusActionLabel(status: OrderStatus): string {
-	switch (status) {
-		case "AWAITING_PAYMENT":
-			return "Awaiting payment";
-		case "PAID":
-			return "Paid";
-		case "IN_PROGRESS":
-			return "In progress";
-		case "READY_FOR_PICKUP":
-			return "Ready for pickup";
-		case "COMPLETED":
-			return "Completed";
-		case "CANCELED":
-			return "Canceled";
-	}
-}
-
-/** Primary CTA label for moving into `to` from the current step (when valid). */
-export function orderStatusAdvanceLabel(to: OrderStatus): string {
-	switch (to) {
-		case "PAID":
-			return "Mark payment received";
-		case "IN_PROGRESS":
-			return "Start order";
-		case "READY_FOR_PICKUP":
-			return "Mark ready for pickup";
-		case "COMPLETED":
-			return "Mark picked up / done";
-		case "CANCELED":
-			return "Cancel order";
-		default:
-			return orderStatusActionLabel(to);
-	}
+export function orderStatusAdvanceLabel(to: FulfillmentStatus): string {
+	return ({ RECEIVED: "Received", IN_PROGRESS: "Start order", READY_FOR_PICKUP: "Mark ready for pickup", COMPLETED: "Mark picked up / done", CANCELED: "Cancel order" })[to];
 }

--- a/lib/orderTracking.test.ts
+++ b/lib/orderTracking.test.ts
@@ -3,39 +3,20 @@ import { createTrackingToken, isValidTrackingToken, toPublicOrderTracking } from
 
 describe("public order tracking", () => {
 	it("creates distinct cryptographically random UUID tracking tokens", () => {
-		const first = createTrackingToken();
-		const second = createTrackingToken();
-
-		expect(first).not.toBe(second);
-		expect(first.slice(0, 18)).not.toBe(second.slice(0, 18));
-		expect(isValidTrackingToken(first)).toBe(true);
-		expect(isValidTrackingToken(second)).toBe(true);
+		const first = createTrackingToken(); const second = createTrackingToken();
+		expect(first).not.toBe(second); expect(isValidTrackingToken(first)).toBe(true); expect(isValidTrackingToken(second)).toBe(true);
 	});
-
-	it("builds the exact allowlisted public shape without customer PII or internal fields", () => {
-		const publicOrder = toPublicOrderTracking("PAID", {
-			items: [{ id: "secret-item-id", name: "Chocolate Cake", price: 25, qty: 2 }],
-			totals: { subtotal: 50, tax: 4, total: 54 },
+	it("returns authoritative snapshots without private payment or customer fields", () => {
+		const result = toPublicOrderTracking("IN_PROGRESS", {
+			payment: { method: "venmo", status: "PAID", venmoUser: "@private", note: "private" },
+			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
+			totals: { subtotalCents: 5000, totalCents: 5000 },
 		});
-
-		expect(publicOrder).toEqual({
-			status: "PAID",
-			items: [{ name: "Chocolate Cake", price: 25, qty: 2 }],
-			total: 54,
+		expect(result).toEqual({
+			fulfillmentStatus: "IN_PROGRESS", payment: { method: "venmo", status: "PAID" },
+			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
+			totals: { subtotalCents: 5000, totalCents: 5000 },
 		});
-		for (const field of [
-			"id",
-			"trackingToken",
-			"customer",
-			"email",
-			"phone",
-			"notes",
-			"paymentMethod",
-			"venmoUser",
-			"venmoNote",
-			"payload",
-		]) {
-			expect(publicOrder).not.toHaveProperty(field);
-		}
+		expect(result.payment).not.toHaveProperty("venmoUser");
 	});
 });

--- a/lib/orderTracking.ts
+++ b/lib/orderTracking.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { OrderRecord, OrderStatus, PublicOrderTracking } from "./orderTypes";
+import type { FulfillmentStatus, OrderRecord, PublicOrderTracking } from "./orderTypes";
 
 const TRACKING_TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -12,16 +12,19 @@ export function isValidTrackingToken(value: string): boolean {
 }
 
 export function toPublicOrderTracking(
-	status: OrderStatus,
-	payload: Pick<OrderRecord, "items" | "totals">,
+	fulfillmentStatus: FulfillmentStatus,
+	payload: Pick<OrderRecord, "payment" | "items" | "totals">,
 ): PublicOrderTracking {
 	return {
-		status,
+		fulfillmentStatus,
+		payment: { method: payload.payment.method, status: payload.payment.status },
 		items: payload.items.map((item) => ({
+			productId: item.productId,
 			name: item.name,
-			price: item.price,
-			qty: item.qty,
+			unitPriceCents: item.unitPriceCents,
+			quantity: item.quantity,
+			lineTotalCents: item.lineTotalCents,
 		})),
-		total: payload.totals.total,
+		totals: payload.totals,
 	};
 }

--- a/lib/orderTypes.ts
+++ b/lib/orderTypes.ts
@@ -1,40 +1,24 @@
-export type OrderStatus = 
-| "AWAITING_PAYMENT"
-| "PAID"
-| "IN_PROGRESS"
-| "READY_FOR_PICKUP"
-| "COMPLETED"
-| "CANCELED";
+export type FulfillmentStatus = "RECEIVED" | "IN_PROGRESS" | "READY_FOR_PICKUP" | "COMPLETED" | "CANCELED";
+export type PaymentMethod = "cash" | "venmo" | "zelle";
+export type PaymentStatus = "PENDING" | "PAID";
 
-export type OrderItem = {id: string; name: string; price: number; qty: number};
+export type OrderItem = {
+	productId: string;
+	name: string;
+	unitPriceCents: number;
+	quantity: number;
+	lineTotalCents: number;
+};
 
 export type OrderRecord = {
-    id: string;
-    createdAt: string;
-    status: OrderStatus;
-    customer: {
-        name: string;
-        email: string;
-        phone?: string;
-        notes?: string;
-        paymentMethod?: "venmo" | "cash";
-        venmoUser?: string;
-        venmoNote?: string;
-    };
-    items: OrderItem[];
-    totals: {subtotal: number; tax: number; total: number};
+	id: string;
+	createdAt: string;
+	fulfillmentStatus: FulfillmentStatus;
+	payment: { method: PaymentMethod; status: PaymentStatus; venmoUser?: string; note?: string };
+	customer: { name: string; email: string; phone?: string; notes?: string };
+	items: OrderItem[];
+	totals: { subtotalCents: number; totalCents: number };
 };
 
-export type PublicOrderTracking = {
-	status: OrderStatus;
-	items: {
-		name: string;
-		price: number;
-		qty: number;
-	}[];
-	total: number;
-};
-
-export type AdminOrderRecord = OrderRecord & {
-	trackingToken: string | null;
-};
+export type PublicOrderTracking = Pick<OrderRecord, "fulfillmentStatus" | "payment" | "items" | "totals">;
+export type AdminOrderRecord = OrderRecord & { trackingToken: string | null };

--- a/lib/orderValidation.test.ts
+++ b/lib/orderValidation.test.ts
@@ -1,118 +1,61 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { validateOrderPayload } from "./orderValidation";
 
+const validPayload = {
+	customer: { name: "Alice Baker", email: "alice@example.com" },
+	payment: { method: "cash" },
+	items: [{ productId: "cake", quantity: 1 }],
+};
+
 describe("validateOrderPayload", () => {
-	it("rejects empty body", () => {
+	it("accepts the trusted cash contract and trims customer input", () => {
+		const result = validateOrderPayload({
+			...validPayload,
+			customer: { ...validPayload.customer, name: "  Alice Baker  ", phone: " 555-0100 " },
+		});
+		expect(result).toEqual({ ok: true, data: {
+			customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100" },
+			payment: { method: "cash" },
+			items: [{ productId: "cake", quantity: 1 }],
+		} });
+	});
+
+	it("accepts Zelle with an optional note", () => {
+		expect(validateOrderPayload({ ...validPayload, payment: { method: "zelle", note: "Alice B" } }).ok).toBe(true);
+	});
+
+	it("requires a Venmo username", () => {
+		expect(validateOrderPayload({ ...validPayload, payment: { method: "venmo" } })).toMatchObject({ ok: false, code: "INVALID_PAYMENT_METHOD" });
+		expect(validateOrderPayload({ ...validPayload, payment: { method: "venmo", venmoUser: "@alice" } }).ok).toBe(true);
+	});
+
+	it("rejects an invalid payment method", () => {
+		expect(validateOrderPayload({ ...validPayload, payment: { method: "card" } })).toMatchObject({ ok: false, code: "INVALID_PAYMENT_METHOD" });
+	});
+
+	it.each([0, -1, 1.5])("rejects invalid quantity %s", (quantity) => {
+		expect(validateOrderPayload({ ...validPayload, items: [{ productId: "cake", quantity }] })).toMatchObject({ ok: false, code: "INVALID_QUANTITY" });
+	});
+
+	it("combines duplicate product IDs before database validation", () => {
+		const result = validateOrderPayload({ ...validPayload, items: [
+			{ productId: "cake", quantity: 12 }, { productId: "cake", quantity: 12 },
+		] });
+		expect(result).toMatchObject({ ok: true, data: { items: [{ productId: "cake", quantity: 24 }] } });
+	});
+
+	it("ignores untrusted catalog and total fields", () => {
+		const result = validateOrderPayload({
+			...validPayload, subtotal: 1, total: 1,
+			items: [{ productId: "cake", quantity: 1, name: "Fake", price: 0 }],
+		});
+		expect(result).toMatchObject({ ok: true, data: { items: [{ productId: "cake", quantity: 1 }] } });
+	});
+
+	it("rejects malformed customer and item input", () => {
 		expect(validateOrderPayload(null).ok).toBe(false);
-		expect(validateOrderPayload(undefined).ok).toBe(false);
-	});
-
-	it("rejects non-object body", () => {
-		expect(validateOrderPayload("string").ok).toBe(false);
-		expect(validateOrderPayload(123).ok).toBe(false);
-	});
-
-	it("rejects missing customer", () => {
-		const result = validateOrderPayload({ items: [], totals: {} });
-		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.error).toContain("customer");
-	});
-
-	it("rejects invalid name", () => {
-		const base = {
-			customer: { name: "A", email: "a@b.com" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		expect(validateOrderPayload({ ...base, customer: { ...base.customer, name: "A" } }).ok).toBe(false);
-		expect(validateOrderPayload({ ...base, customer: { ...base.customer, name: "" } }).ok).toBe(false);
-	});
-
-	it("rejects invalid email", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		expect(validateOrderPayload({ ...base, customer: { ...base.customer, email: "invalid" } }).ok).toBe(false);
-		expect(validateOrderPayload({ ...base, customer: { ...base.customer, email: "" } }).ok).toBe(false);
-	});
-
-	it("rejects venmo without venmoUser", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com", paymentMethod: "venmo" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		const result = validateOrderPayload(base);
-		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.error).toContain("venmoUser");
-	});
-
-	it("accepts venmo with venmoUser", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com", paymentMethod: "venmo", venmoUser: "@alice" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		const result = validateOrderPayload(base);
-		expect(result.ok).toBe(true);
-		if (result.ok) expect(result.data.customer.venmoUser).toBe("@alice");
-	});
-
-	it("accepts cash without venmoUser", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com", paymentMethod: "cash" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		const result = validateOrderPayload(base);
-		expect(result.ok).toBe(true);
-	});
-
-	it("rejects empty items", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com", paymentMethod: "cash" },
-			items: [],
-			totals: { subtotal: 0, tax: 0, total: 0 },
-		};
-		const result = validateOrderPayload(base);
-		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.error).toContain("empty");
-	});
-
-	it("rejects invalid item (negative price)", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com" },
-			items: [{ id: "x", name: "Item", price: -1, qty: 1 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		expect(validateOrderPayload(base).ok).toBe(false);
-	});
-
-	it("rejects invalid item (qty < 1)", () => {
-		const base = {
-			customer: { name: "Alice", email: "a@b.com" },
-			items: [{ id: "x", name: "Item", price: 1, qty: 0 }],
-			totals: { subtotal: 1, tax: 0, total: 1 },
-		};
-		expect(validateOrderPayload(base).ok).toBe(false);
-	});
-
-	it("accepts valid minimal order (cash)", () => {
-		const payload = {
-			customer: { name: "Alice", email: "a@b.com", paymentMethod: "cash" },
-			items: [{ id: "cake", name: "Chocolate Cake", price: 25, qty: 1 }],
-			totals: { subtotal: 25, tax: 0, total: 25 },
-		};
-		const result = validateOrderPayload(payload);
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data.customer.name).toBe("Alice");
-			expect(result.data.customer.email).toBe("a@b.com");
-			expect(result.data.customer.paymentMethod).toBe("cash");
-			expect(result.data.items).toHaveLength(1);
-			expect(result.data.items[0]).toEqual({ id: "cake", name: "Chocolate Cake", price: 25, qty: 1 });
-		}
+		expect(validateOrderPayload({ ...validPayload, customer: { name: "A", email: "bad" } }).ok).toBe(false);
+		expect(validateOrderPayload({ ...validPayload, items: [] }).ok).toBe(false);
+		expect(validateOrderPayload({ ...validPayload, items: [{ productId: "", quantity: 1 }] }).ok).toBe(false);
 	});
 });

--- a/lib/orderValidation.ts
+++ b/lib/orderValidation.ts
@@ -1,190 +1,65 @@
-/**
- * Server-side validation for order API payloads.
- * Validates structure, types, and constraints before persisting.
- */
-
-import type { OrderRecord } from "./orderTypes";
+import type { PaymentMethod } from "./orderTypes";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MAX_NAME_LEN = 200;
-const MAX_EMAIL_LEN = 254;
-const MAX_PHONE_LEN = 30;
-const MAX_NOTES_LEN = 2000;
-const MAX_VENMO_USER_LEN = 50;
-const MAX_VENMO_NOTE_LEN = 200;
 const MAX_ITEMS = 50;
-const MAX_ITEM_NAME_LEN = 200;
-const MAX_ITEM_ID_LEN = 100;
+const LIMITS = { name: 200, email: 254, phone: 30, notes: 2000, productId: 100, venmoUser: 50, paymentNote: 200 };
 
-export function validateOrderPayload(
-	body: unknown
-): { ok: true; data: Pick<OrderRecord, "customer" | "items" | "totals"> } | { ok: false; error: string } {
-	if (!body || typeof body !== "object") {
-		return { ok: false, error: "Invalid request body" };
+type TrustedOrderRequest = {
+	customer: { name: string; email: string; phone?: string; notes?: string };
+	payment: { method: PaymentMethod; venmoUser?: string; note?: string };
+	items: { productId: string; quantity: number }[];
+};
+
+type ValidationError = { ok: false; code: "INVALID_ORDER" | "INVALID_QUANTITY" | "INVALID_PAYMENT_METHOD"; error: string };
+
+function optionalString(value: unknown, field: string, max: number): string | ValidationError | undefined {
+	if (value === undefined || value === null || value === "") return undefined;
+	if (typeof value !== "string" || value.length > max) return { ok: false, code: "INVALID_ORDER", error: `${field} must be at most ${max} characters` };
+	return value.trim() || undefined;
+}
+
+export function validateOrderPayload(body: unknown): { ok: true; data: TrustedOrderRequest } | ValidationError {
+	if (!body || typeof body !== "object") return { ok: false, code: "INVALID_ORDER", error: "Invalid request body" };
+	const input = body as Record<string, unknown>;
+	if (!input.customer || typeof input.customer !== "object") return { ok: false, code: "INVALID_ORDER", error: "Customer information is required" };
+	if (!input.payment || typeof input.payment !== "object") return { ok: false, code: "INVALID_PAYMENT_METHOD", error: "Payment method is required" };
+	if (!Array.isArray(input.items) || input.items.length === 0 || input.items.length > MAX_ITEMS) return { ok: false, code: "INVALID_ORDER", error: `Order must contain between 1 and ${MAX_ITEMS} items` };
+
+	const customerInput = input.customer as Record<string, unknown>;
+	const name = typeof customerInput.name === "string" ? customerInput.name.trim() : "";
+	const email = typeof customerInput.email === "string" ? customerInput.email.trim() : "";
+	if (name.length < 2 || name.length > LIMITS.name) return { ok: false, code: "INVALID_ORDER", error: "Enter a valid customer name" };
+	if (!EMAIL_REGEX.test(email) || email.length > LIMITS.email) return { ok: false, code: "INVALID_ORDER", error: "Enter a valid email address" };
+	const phone = optionalString(customerInput.phone, "customer.phone", LIMITS.phone);
+	if (phone && typeof phone !== "string") return phone;
+	const notes = optionalString(customerInput.notes, "customer.notes", LIMITS.notes);
+	if (notes && typeof notes !== "string") return notes;
+
+	const paymentInput = input.payment as Record<string, unknown>;
+	const method = paymentInput.method;
+	if (method !== "cash" && method !== "venmo" && method !== "zelle") return { ok: false, code: "INVALID_PAYMENT_METHOD", error: "Choose Cash, Venmo, or Zelle" };
+	const venmoUser = optionalString(paymentInput.venmoUser, "payment.venmoUser", LIMITS.venmoUser);
+	if (venmoUser && typeof venmoUser !== "string") return venmoUser;
+	if (method === "venmo" && !venmoUser) return { ok: false, code: "INVALID_PAYMENT_METHOD", error: "Venmo username is required" };
+	const note = optionalString(paymentInput.note, "payment.note", LIMITS.paymentNote);
+	if (note && typeof note !== "string") return note;
+
+	const quantities = new Map<string, number>();
+	for (let index = 0; index < input.items.length; index += 1) {
+		const item = input.items[index];
+		if (!item || typeof item !== "object") return { ok: false, code: "INVALID_ORDER", error: `Item ${index + 1} is invalid` };
+		const value = item as Record<string, unknown>;
+		const productId = typeof value.productId === "string" ? value.productId.trim() : "";
+		if (!productId || productId.length > LIMITS.productId) return { ok: false, code: "INVALID_ORDER", error: `Item ${index + 1} has an invalid product ID` };
+		if (!Number.isSafeInteger(value.quantity) || (value.quantity as number) <= 0) return { ok: false, code: "INVALID_QUANTITY", error: "Quantities must be positive whole numbers" };
+		const combined = (quantities.get(productId) ?? 0) + (value.quantity as number);
+		if (!Number.isSafeInteger(combined)) return { ok: false, code: "INVALID_QUANTITY", error: "Quantity is too large" };
+		quantities.set(productId, combined);
 	}
 
-	const obj = body as Record<string, unknown>;
-	const customer = obj.customer;
-	const items = obj.items;
-	const totals = obj.totals;
-
-	if (!customer || typeof customer !== "object") {
-		return { ok: false, error: "customer is required" };
-	}
-	if (!Array.isArray(items)) {
-		return { ok: false, error: "items must be an array" };
-	}
-	if (!totals || typeof totals !== "object") {
-		return { ok: false, error: "totals is required" };
-	}
-
-	const cust = customer as Record<string, unknown>;
-	const name = cust.name;
-	const email = cust.email;
-
-	if (typeof name !== "string" || name.trim().length < 2) {
-		return { ok: false, error: "customer.name must be at least 2 characters" };
-	}
-	if (name.length > MAX_NAME_LEN) {
-		return { ok: false, error: `customer.name must be at most ${MAX_NAME_LEN} characters` };
-	}
-
-	if (typeof email !== "string" || !EMAIL_REGEX.test(email.trim())) {
-		return { ok: false, error: "customer.email must be a valid email" };
-	}
-	if (email.length > MAX_EMAIL_LEN) {
-		return { ok: false, error: `customer.email must be at most ${MAX_EMAIL_LEN} characters` };
-	}
-
-	const phone = cust.phone;
-	if (phone !== undefined && phone !== null) {
-		if (typeof phone !== "string") {
-			return { ok: false, error: "customer.phone must be a string" };
-		}
-		if (phone.length > MAX_PHONE_LEN) {
-			return { ok: false, error: `customer.phone must be at most ${MAX_PHONE_LEN} characters` };
-		}
-	}
-
-	const notes = cust.notes;
-	if (notes !== undefined && notes !== null) {
-		if (typeof notes !== "string") {
-			return { ok: false, error: "customer.notes must be a string" };
-		}
-		if (notes.length > MAX_NOTES_LEN) {
-			return { ok: false, error: `customer.notes must be at most ${MAX_NOTES_LEN} characters` };
-		}
-	}
-
-	const paymentMethod = cust.paymentMethod;
-	const effectivePaymentMethod = paymentMethod === "cash" ? "cash" : "venmo";
-	if (paymentMethod !== undefined && paymentMethod !== null && paymentMethod !== "venmo" && paymentMethod !== "cash") {
-		return { ok: false, error: "customer.paymentMethod must be 'venmo' or 'cash'" };
-	}
-	if (effectivePaymentMethod === "venmo") {
-		const venmoUser = cust.venmoUser;
-		if (typeof venmoUser !== "string" || venmoUser.trim().length === 0) {
-			return { ok: false, error: "customer.venmoUser is required when paymentMethod is venmo" };
-		}
-		if (venmoUser.length > MAX_VENMO_USER_LEN) {
-			return { ok: false, error: `customer.venmoUser must be at most ${MAX_VENMO_USER_LEN} characters` };
-		}
-	}
-
-	const venmoNote = cust.venmoNote;
-	if (venmoNote !== undefined && venmoNote !== null) {
-		if (typeof venmoNote !== "string") {
-			return { ok: false, error: "customer.venmoNote must be a string" };
-		}
-		if (venmoNote.length > MAX_VENMO_NOTE_LEN) {
-			return { ok: false, error: `customer.venmoNote must be at most ${MAX_VENMO_NOTE_LEN} characters` };
-		}
-	}
-
-	if (items.length === 0) {
-		return { ok: false, error: "items cannot be empty" };
-	}
-	if (items.length > MAX_ITEMS) {
-		return { ok: false, error: `items cannot exceed ${MAX_ITEMS}` };
-	}
-
-	const validatedItems: { id: string; name: string; price: number; qty: number }[] = [];
-	for (let i = 0; i < items.length; i++) {
-		const item = items[i];
-		if (!item || typeof item !== "object") {
-			return { ok: false, error: `items[${i}] must be an object` };
-		}
-		const it = item as Record<string, unknown>;
-		const id = it.id;
-		const itemName = it.name;
-		const price = it.price;
-		const qty = it.qty;
-
-		if (typeof id !== "string" || id.trim().length === 0) {
-			return { ok: false, error: `items[${i}].id is required` };
-		}
-		if (id.length > MAX_ITEM_ID_LEN) {
-			return { ok: false, error: `items[${i}].id must be at most ${MAX_ITEM_ID_LEN} characters` };
-		}
-
-		if (typeof itemName !== "string" || itemName.trim().length === 0) {
-			return { ok: false, error: `items[${i}].name is required` };
-		}
-		if (itemName.length > MAX_ITEM_NAME_LEN) {
-			return { ok: false, error: `items[${i}].name must be at most ${MAX_ITEM_NAME_LEN} characters` };
-		}
-
-		if (typeof price !== "number" || !Number.isFinite(price) || price < 0) {
-			return { ok: false, error: `items[${i}].price must be a non-negative number` };
-		}
-
-		if (typeof qty !== "number" || !Number.isInteger(qty) || qty < 1) {
-			return { ok: false, error: `items[${i}].qty must be a positive integer` };
-		}
-
-		validatedItems.push({
-			id: id.trim(),
-			name: itemName.trim(),
-			price,
-			qty,
-		});
-	}
-
-	const tot = totals as Record<string, unknown>;
-	const subtotal = tot.subtotal;
-	const tax = tot.tax;
-	const total = tot.total;
-
-	if (typeof subtotal !== "number" || !Number.isFinite(subtotal) || subtotal < 0) {
-		return { ok: false, error: "totals.subtotal must be a non-negative number" };
-	}
-	if (typeof tax !== "number" || !Number.isFinite(tax) || tax < 0) {
-		return { ok: false, error: "totals.tax must be a non-negative number" };
-	}
-	if (typeof total !== "number" || !Number.isFinite(total) || total < 0) {
-		return { ok: false, error: "totals.total must be a non-negative number" };
-	}
-
-	const customerPayload: OrderRecord["customer"] = {
-		name: name.trim(),
-		email: email.trim(),
-		...(phone !== undefined && phone !== null && { phone: String(phone).trim() }),
-		...(notes !== undefined && notes !== null && { notes: String(notes).trim() }),
-		paymentMethod: effectivePaymentMethod,
-		...(cust.venmoUser !== undefined && cust.venmoUser !== null && {
-			venmoUser: String(cust.venmoUser).trim(),
-		}),
-		...(venmoNote !== undefined && venmoNote !== null && {
-			venmoNote: String(venmoNote).trim(),
-		}),
-	};
-
-	return {
-		ok: true,
-		data: {
-			customer: customerPayload,
-			items: validatedItems,
-			totals: { subtotal, tax, total },
-		},
-	};
+	return { ok: true, data: {
+		customer: { name, email, ...(phone && { phone }), ...(notes && { notes }) },
+		payment: { method, ...(method === "venmo" && venmoUser && { venmoUser }), ...(note && { note }) },
+		items: [...quantities].map(([productId, quantity]) => ({ productId, quantity })),
+	} };
 }

--- a/scripts/test-inventory-db.sh
+++ b/scripts/test-inventory-db.sh
@@ -25,7 +25,8 @@ docker exec "$container" pg_isready -U postgres -d "$database" >/dev/null
 docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" <<'SQL'
 CREATE ROLE anon NOLOGIN;
 CREATE ROLE authenticated NOLOGIN;
-CREATE ROLE service_role NOLOGIN;
+CREATE ROLE service_role NOLOGIN BYPASSRLS;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
 SQL
 
 for migration in supabase/migrations/*.sql; do
@@ -34,8 +35,8 @@ done
 docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
     < supabase/tests/current_product_inventory.sql >/dev/null
 
-reservation_one="SELECT public.create_order_with_reserve('race_1','track_race_1','{\"items\":[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]}'::jsonb,'[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]'::jsonb);"
-reservation_two="SELECT public.create_order_with_reserve('race_2','track_race_2','{\"items\":[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]}'::jsonb,'[{\"id\":\"cookie_chocolatechip\",\"qty\":1}]'::jsonb);"
+reservation_one="SELECT public.create_authoritative_order('race_1','track_race_1','{\"name\":\"Race One\",\"email\":\"one@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"
+reservation_two="SELECT public.create_authoritative_order('race_2','track_race_2','{\"name\":\"Race Two\",\"email\":\"two@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"
 
 docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$reservation_one" >"$results_dir/one" 2>&1 &
 pid_one=$!

--- a/supabase/migrations/20260909200000_server_authoritative_checkout.sql
+++ b/supabase/migrations/20260909200000_server_authoritative_checkout.sql
@@ -1,0 +1,186 @@
+-- Build the accepted order snapshot from the catalog and reserve stock in one transaction.
+
+ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.orders FROM anon, authenticated;
+GRANT ALL ON TABLE public.orders TO service_role;
+
+DROP FUNCTION IF EXISTS public.create_order_with_reserve(TEXT, TEXT, JSONB, JSONB);
+
+CREATE FUNCTION public.create_authoritative_order(
+    p_order_id TEXT,
+    p_tracking_token TEXT,
+    p_customer JSONB,
+    p_payment JSONB,
+    p_items JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    item JSONB;
+    requested RECORD;
+    product RECORD;
+    current_quantity INTEGER;
+    changed_rows INTEGER;
+    numeric_quantity NUMERIC;
+    subtotal_cents BIGINT := 0;
+    order_items JSONB := '[]'::jsonb;
+    payment_snapshot JSONB;
+    order_snapshot JSONB;
+    created_at TIMESTAMPTZ := now();
+BEGIN
+    IF jsonb_typeof(p_customer) IS DISTINCT FROM 'object' THEN
+        RAISE EXCEPTION 'INVALID_ORDER';
+    END IF;
+    IF jsonb_typeof(p_payment) IS DISTINCT FROM 'object'
+        OR p_payment->>'method' NOT IN ('cash', 'venmo', 'zelle') THEN
+        RAISE EXCEPTION 'INVALID_PAYMENT_METHOD';
+    END IF;
+    IF p_payment->>'method' = 'venmo' AND btrim(COALESCE(p_payment->>'venmoUser', '')) = '' THEN
+        RAISE EXCEPTION 'INVALID_PAYMENT_METHOD';
+    END IF;
+    IF jsonb_typeof(p_items) IS DISTINCT FROM 'array' OR jsonb_array_length(p_items) = 0 THEN
+        RAISE EXCEPTION 'INVALID_QUANTITY';
+    END IF;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(p_items)
+    LOOP
+        IF jsonb_typeof(item) IS DISTINCT FROM 'object'
+            OR jsonb_typeof(item->'productId') IS DISTINCT FROM 'string'
+            OR btrim(item->>'productId') = ''
+            OR jsonb_typeof(item->'quantity') IS DISTINCT FROM 'number' THEN
+            RAISE EXCEPTION 'INVALID_QUANTITY';
+        END IF;
+        numeric_quantity := (item->>'quantity')::numeric;
+        IF numeric_quantity <= 0 OR numeric_quantity <> trunc(numeric_quantity) OR numeric_quantity > 2147483647 THEN
+            RAISE EXCEPTION 'INVALID_QUANTITY';
+        END IF;
+    END LOOP;
+
+    -- Aggregate duplicates, then lock in stable order to prevent deadlocks and max-limit bypasses.
+    FOR requested IN
+        SELECT value->>'productId' AS product_id, SUM((value->>'quantity')::bigint) AS quantity
+        FROM jsonb_array_elements(p_items)
+        GROUP BY value->>'productId'
+        ORDER BY value->>'productId'
+    LOOP
+        IF requested.quantity > 2147483647 THEN RAISE EXCEPTION 'INVALID_QUANTITY'; END IF;
+
+        SELECT id, name, price_cents, max_per_order, is_archived
+        INTO product
+        FROM public.products
+        WHERE id = requested.product_id
+        FOR SHARE;
+
+        IF NOT FOUND THEN RAISE EXCEPTION 'INVALID_PRODUCT'; END IF;
+        IF product.is_archived THEN RAISE EXCEPTION 'PRODUCT_UNAVAILABLE'; END IF;
+        IF requested.quantity > product.max_per_order THEN RAISE EXCEPTION 'MAX_QUANTITY_EXCEEDED'; END IF;
+
+        SELECT quantity_on_hand INTO current_quantity
+        FROM public.product_inventory
+        WHERE product_id = requested.product_id
+        FOR UPDATE;
+
+        IF NOT FOUND OR current_quantity < requested.quantity THEN RAISE EXCEPTION 'OUT_OF_STOCK'; END IF;
+
+        UPDATE public.product_inventory
+        SET quantity_on_hand = quantity_on_hand - requested.quantity::integer
+        WHERE product_id = requested.product_id AND quantity_on_hand >= requested.quantity;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+        IF changed_rows <> 1 THEN RAISE EXCEPTION 'OUT_OF_STOCK'; END IF;
+
+        subtotal_cents := subtotal_cents + (product.price_cents::bigint * requested.quantity);
+        order_items := order_items || jsonb_build_array(jsonb_build_object(
+            'productId', product.id,
+            'name', product.name,
+            'unitPriceCents', product.price_cents,
+            'quantity', requested.quantity,
+            'lineTotalCents', product.price_cents::bigint * requested.quantity
+        ));
+    END LOOP;
+
+    payment_snapshot := jsonb_strip_nulls(jsonb_build_object(
+        'method', p_payment->>'method',
+        'status', 'PENDING',
+        'venmoUser', p_payment->'venmoUser',
+        'note', p_payment->'note'
+    ));
+    order_snapshot := jsonb_build_object(
+        'id', p_order_id,
+        'createdAt', created_at,
+        'fulfillmentStatus', 'RECEIVED',
+        'payment', payment_snapshot,
+        'customer', p_customer,
+        'items', order_items,
+        'totals', jsonb_build_object('subtotalCents', subtotal_cents, 'totalCents', subtotal_cents)
+    );
+
+    INSERT INTO public.orders (id, tracking_token, status, payload, created_at)
+    VALUES (p_order_id, p_tracking_token, 'RECEIVED', order_snapshot, created_at);
+
+    RETURN jsonb_build_object('id', p_order_id, 'order', order_snapshot);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cancel_order_and_restore_inventory(p_order_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    order_status TEXT;
+    order_payload JSONB;
+    item JSONB;
+    reserved RECORD;
+    changed_rows INTEGER;
+    numeric_quantity NUMERIC;
+BEGIN
+    SELECT orders.status, orders.payload INTO order_status, order_payload
+    FROM public.orders WHERE orders.id = p_order_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'ORDER_NOT_FOUND'; END IF;
+    IF order_status = 'CANCELED' THEN RETURN jsonb_build_object('id', p_order_id, 'canceled', true, 'restored', false); END IF;
+    IF order_status = 'COMPLETED' THEN RAISE EXCEPTION 'ORDER_NOT_CANCELABLE'; END IF;
+    IF jsonb_typeof(order_payload->'items') IS DISTINCT FROM 'array' THEN RAISE EXCEPTION 'ORDER_FAILED'; END IF;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(order_payload->'items')
+    LOOP
+        IF jsonb_typeof(item) IS DISTINCT FROM 'object'
+            OR jsonb_typeof(item->'productId') IS DISTINCT FROM 'string'
+            OR jsonb_typeof(item->'quantity') IS DISTINCT FROM 'number' THEN
+            RAISE EXCEPTION 'ORDER_FAILED';
+        END IF;
+        numeric_quantity := (item->>'quantity')::numeric;
+        IF numeric_quantity <= 0 OR numeric_quantity <> trunc(numeric_quantity) OR numeric_quantity > 2147483647 THEN
+            RAISE EXCEPTION 'ORDER_FAILED';
+        END IF;
+    END LOOP;
+
+    FOR reserved IN
+        SELECT value->>'productId' AS product_id, SUM((value->>'quantity')::bigint) AS quantity
+        FROM jsonb_array_elements(order_payload->'items')
+        GROUP BY value->>'productId' ORDER BY value->>'productId'
+    LOOP
+        UPDATE public.product_inventory SET quantity_on_hand = quantity_on_hand + reserved.quantity::integer
+        WHERE product_id = reserved.product_id;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+        IF changed_rows <> 1 THEN RAISE EXCEPTION 'ORDER_FAILED'; END IF;
+    END LOOP;
+
+    UPDATE public.orders
+    SET status = 'CANCELED', payload = jsonb_set(order_payload, '{fulfillmentStatus}', '"CANCELED"'::jsonb, true)
+    WHERE id = p_order_id;
+    RETURN jsonb_build_object('id', p_order_id, 'canceled', true, 'restored', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB) TO service_role;
+
+COMMENT ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB)
+IS 'Atomically validates catalog and stock, calculates cents, reserves inventory, and stores an immutable order snapshot.';
+
+COMMENT ON TABLE public.orders
+IS 'Private order records. Browser roles have no direct access; server routes use service_role.';

--- a/supabase/migrations/20260909201000_private_flavor_requests.sql
+++ b/supabase/migrations/20260909201000_private_flavor_requests.sql
@@ -1,0 +1,8 @@
+-- Flavor requests contain customer contact details and are only accessed through server routes.
+
+ALTER TABLE public.flavor_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.flavor_requests FROM anon, authenticated;
+GRANT ALL ON TABLE public.flavor_requests TO service_role;
+
+COMMENT ON TABLE public.flavor_requests
+IS 'Private customer flavor requests. Browser roles have no direct access; server routes use service_role.';

--- a/supabase/tests/current_product_inventory.sql
+++ b/supabase/tests/current_product_inventory.sql
@@ -5,180 +5,180 @@ BEGIN
 END;
 $$;
 
+CREATE FUNCTION pg_temp.place(test_id TEXT, payment JSONB, items JSONB)
+RETURNS JSONB LANGUAGE sql AS $$
+    SELECT public.create_authoritative_order(
+        test_id, 'track_' || test_id,
+        '{"name":"Test Customer","email":"test@example.com"}'::jsonb,
+        payment, items
+    );
+$$;
+
 SELECT pg_temp.assert_true(
-    (SELECT count(*) = (SELECT count(*) FROM public.products)
-     FROM public.product_inventory),
+    (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.orders'::regclass),
+    'orders has row-level security enabled'
+);
+SELECT pg_temp.assert_true(
+    NOT has_table_privilege('anon', 'public.orders', 'SELECT')
+    AND NOT has_table_privilege('anon', 'public.orders', 'INSERT')
+    AND NOT has_table_privilege('anon', 'public.orders', 'UPDATE')
+    AND NOT has_table_privilege('anon', 'public.orders', 'DELETE')
+    AND NOT has_table_privilege('authenticated', 'public.orders', 'SELECT')
+    AND NOT has_table_privilege('authenticated', 'public.orders', 'INSERT')
+    AND NOT has_table_privilege('authenticated', 'public.orders', 'UPDATE')
+    AND NOT has_table_privilege('authenticated', 'public.orders', 'DELETE'),
+    'browser roles have no direct orders privileges'
+);
+SELECT pg_temp.assert_true(
+    has_table_privilege('service_role', 'public.orders', 'SELECT')
+    AND has_table_privilege('service_role', 'public.orders', 'INSERT')
+    AND has_table_privilege('service_role', 'public.orders', 'UPDATE')
+    AND has_table_privilege('service_role', 'public.orders', 'DELETE'),
+    'service role retains server-side orders access'
+);
+SELECT pg_temp.assert_true(
+    (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.flavor_requests'::regclass),
+    'flavor_requests has row-level security enabled'
+);
+SELECT pg_temp.assert_true(
+    NOT has_table_privilege('anon', 'public.flavor_requests', 'SELECT')
+    AND NOT has_table_privilege('anon', 'public.flavor_requests', 'INSERT')
+    AND NOT has_table_privilege('anon', 'public.flavor_requests', 'UPDATE')
+    AND NOT has_table_privilege('anon', 'public.flavor_requests', 'DELETE')
+    AND NOT has_table_privilege('authenticated', 'public.flavor_requests', 'SELECT')
+    AND NOT has_table_privilege('authenticated', 'public.flavor_requests', 'INSERT')
+    AND NOT has_table_privilege('authenticated', 'public.flavor_requests', 'UPDATE')
+    AND NOT has_table_privilege('authenticated', 'public.flavor_requests', 'DELETE'),
+    'browser roles have no direct flavor_requests privileges'
+);
+SELECT pg_temp.assert_true(
+    has_table_privilege('service_role', 'public.flavor_requests', 'SELECT')
+    AND has_table_privilege('service_role', 'public.flavor_requests', 'INSERT')
+    AND has_table_privilege('service_role', 'public.flavor_requests', 'UPDATE')
+    AND has_table_privilege('service_role', 'public.flavor_requests', 'DELETE'),
+    'service role retains server-side flavor_requests access'
+);
+
+SELECT pg_temp.assert_true(
+    (SELECT count(*) = (SELECT count(*) FROM public.products) FROM public.product_inventory),
     'migration seeds every existing product'
 );
-SELECT pg_temp.assert_true(
-    NOT EXISTS (SELECT 1 FROM public.product_inventory WHERE quantity_on_hand <> 0),
-    'existing products start at zero'
-);
 
-INSERT INTO public.products (
-    id, category_id, name, price_cents, max_per_order, is_archived
-) VALUES ('test_new_product', 'cookies', 'New Product', 100, 10, false);
+UPDATE public.product_inventory SET quantity_on_hand = 10 WHERE product_id IN ('cakepop_chocolate', 'cakepop_vanilla');
+SELECT pg_temp.place('test_single', '{"method":"cash"}', '[{"productId":"cakepop_chocolate","quantity":2}]');
 SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 0 FROM public.product_inventory WHERE product_id = 'test_new_product'),
-    'new products automatically receive zero inventory'
-);
-
-UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_chocolate';
-SELECT public.create_order_with_reserve(
-    'test_basic', 'track_basic',
-    '{"status":"AWAITING_PAYMENT","items":[{"id":"cakepop_chocolate","qty":2}]}'::jsonb,
-    '[{"id":"cakepop_chocolate","qty":2}]'::jsonb
+    (SELECT quantity_on_hand = 8 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
+    'valid order decrements current stock'
 );
 SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
-    'stock 5 order 2 leaves 3'
+    (SELECT payload->>'fulfillmentStatus' = 'RECEIVED'
+        AND payload->'payment'->>'status' = 'PENDING'
+        AND payload->'items'->0->>'name' = 'Chocolate Cake Pop'
+        AND (payload->'items'->0->>'unitPriceCents')::int = 250
+        AND (payload->'items'->0->>'lineTotalCents')::int = 500
+        AND (payload->'totals'->>'subtotalCents')::int = 500
+        AND (payload->'totals'->>'totalCents')::int = 500
+     FROM public.orders WHERE id = 'test_single'),
+    'snapshot and integer-cent totals are authoritative'
 );
 
-UPDATE public.product_inventory SET quantity_on_hand = 0 WHERE product_id = 'cakepop_vanilla';
+SELECT pg_temp.place('test_multi', '{"method":"zelle","note":"Test Customer"}',
+    '[{"productId":"cakepop_chocolate","quantity":1},{"productId":"cakepop_vanilla","quantity":2}]');
+SELECT pg_temp.assert_true(
+    (SELECT (payload->'totals'->>'subtotalCents')::int = 750 FROM public.orders WHERE id = 'test_multi'),
+    'multi-item subtotal is the sum of server prices'
+);
+
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_zero', 'track_zero',
-            '{"items":[{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
-            '[{"id":"cakepop_vanilla","qty":1}]'::jsonb
-        );
-        RAISE EXCEPTION 'zero stock order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'zero stock order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_unknown', '{"method":"cash"}', '[{"productId":"unknown","quantity":1}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'INVALID_PRODUCT%' THEN RAISE; END IF; END;
+END $$;
+
+UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cupcake_chocolate';
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place('test_archived', '{"method":"cash"}', '[{"productId":"cupcake_chocolate","quantity":1}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PRODUCT_UNAVAILABLE%' THEN RAISE; END IF; END;
 END $$;
 
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_invalid_quantity', 'track_invalid_quantity',
-            '{"items":[{"id":"cakepop_vanilla","qty":0}]}'::jsonb,
-            '[{"id":"cakepop_vanilla","qty":0}]'::jsonb
-        );
-        RAISE EXCEPTION 'invalid quantity order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'invalid quantity order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_zero', '{"method":"cash"}', '[{"productId":"cakepop_chocolate","quantity":0}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'INVALID_QUANTITY%' THEN RAISE; END IF; END;
 END $$;
 
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_unknown_product', 'track_unknown_product',
-            '{"items":[{"id":"not_a_product","qty":1}]}'::jsonb,
-            '[{"id":"not_a_product","qty":1}]'::jsonb
-        );
-        RAISE EXCEPTION 'unknown product order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'unknown product order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_max', '{"method":"cash"}',
+            '[{"productId":"cakepop_chocolate","quantity":7},{"productId":"cakepop_chocolate","quantity":6}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'MAX_QUANTITY_EXCEEDED%' THEN RAISE; END IF; END;
 END $$;
 
-DELETE FROM public.product_inventory WHERE product_id = 'test_new_product';
+UPDATE public.product_inventory SET quantity_on_hand = 0 WHERE product_id = 'cookie_snickerdoodle';
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_missing', 'track_missing',
-            '{"items":[{"id":"test_new_product","qty":1}]}'::jsonb,
-            '[{"id":"test_new_product","qty":1}]'::jsonb
-        );
-        RAISE EXCEPTION 'missing inventory order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'missing inventory order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_sold_out', '{"method":"cash"}', '[{"productId":"cookie_snickerdoodle","quantity":1}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'OUT_OF_STOCK%' THEN RAISE; END IF; END;
 END $$;
 
 UPDATE public.product_inventory SET quantity_on_hand = 2 WHERE product_id = 'cupcake_redvelvet';
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_insufficient', 'track_insufficient',
-            '{"items":[{"id":"cupcake_redvelvet","qty":3}]}'::jsonb,
-            '[{"id":"cupcake_redvelvet","qty":3}]'::jsonb
-        );
-        RAISE EXCEPTION 'insufficient stock order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'insufficient stock order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_insufficient', '{"method":"cash"}', '[{"productId":"cupcake_redvelvet","quantity":3}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'OUT_OF_STOCK%' THEN RAISE; END IF; END;
 END $$;
 SELECT pg_temp.assert_true(
     (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cupcake_redvelvet'),
-    'insufficient reservation leaves stock unchanged'
+    'insufficient stock rejection does not decrement inventory'
 );
+
+INSERT INTO public.products (id, category_id, name, price_cents, max_per_order) VALUES ('test_missing_stock', 'cookies', 'Missing Stock', 125, 5);
+DELETE FROM public.product_inventory WHERE product_id = 'test_missing_stock';
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place('test_missing', '{"method":"cash"}', '[{"productId":"test_missing_stock","quantity":1}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'OUT_OF_STOCK%' THEN RAISE; END IF; END;
+END $$;
 
 UPDATE public.product_inventory SET quantity_on_hand = 2 WHERE product_id = 'cakepop_chocolate';
 UPDATE public.product_inventory SET quantity_on_hand = 0 WHERE product_id = 'cakepop_vanilla';
 DO $$ BEGIN
     BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_partial', 'track_partial',
-            '{"items":[{"id":"cakepop_chocolate","qty":1},{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
-            '[{"id":"cakepop_chocolate","qty":1},{"id":"cakepop_vanilla","qty":1}]'::jsonb
-        );
-        RAISE EXCEPTION 'partial order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'partial order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
+        PERFORM pg_temp.place('test_atomic', '{"method":"cash"}',
+            '[{"productId":"cakepop_chocolate","quantity":1},{"productId":"cakepop_vanilla","quantity":1}]');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'OUT_OF_STOCK%' THEN RAISE; END IF; END;
 END $$;
-SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
-    'multi-item failure rolls back prior decrement'
-);
-
-UPDATE public.product_inventory SET quantity_on_hand = 4 WHERE product_id = 'cakepop_chocolate';
-UPDATE public.product_inventory SET quantity_on_hand = 3 WHERE product_id = 'cakepop_vanilla';
-SELECT public.create_order_with_reserve(
-    'test_multi', 'track_multi',
-    '{"status":"AWAITING_PAYMENT","items":[{"id":"cakepop_chocolate","qty":2},{"id":"cakepop_vanilla","qty":1}]}'::jsonb,
-    '[{"id":"cakepop_chocolate","qty":2},{"id":"cakepop_vanilla","qty":1}]'::jsonb
-);
 SELECT pg_temp.assert_true(
     (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
-    AND (SELECT quantity_on_hand = 2 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla'),
-    'successful multi-item order decrements every product'
+    AND NOT EXISTS (SELECT 1 FROM public.orders WHERE id = 'test_atomic'),
+    'multi-item failure consumes no stock and creates no order'
 );
 
-UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cupcake_chocolate';
-DO $$ BEGIN
-    BEGIN
-        PERFORM public.create_order_with_reserve(
-            'test_archived', 'track_archived',
-            '{"items":[{"id":"cupcake_chocolate","qty":1}]}'::jsonb,
-            '[{"id":"cupcake_chocolate","qty":1}]'::jsonb
-        );
-        RAISE EXCEPTION 'archived product order unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'archived product order unexpectedly succeeded' THEN RAISE; END IF;
-    END;
-END $$;
-
-SELECT public.cancel_order_and_restore_inventory('test_multi');
+UPDATE public.product_inventory SET quantity_on_hand = 3 WHERE product_id = 'cookie_chocolatechip';
+SELECT pg_temp.place('test_snapshot', '{"method":"venmo","venmoUser":"@customer"}',
+    '[{"productId":"cookie_chocolatechip","quantity":1}]');
+UPDATE public.products SET name = 'Renamed Cookie', price_cents = 999 WHERE id = 'cookie_chocolatechip';
 SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
-    AND (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla')
-    AND (SELECT status = 'CANCELED' AND payload->>'status' = 'CANCELED' FROM public.orders WHERE id = 'test_multi'),
-    'cancellation restores all items and both status representations'
-);
-SELECT public.cancel_order_and_restore_inventory('test_multi');
-SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
-    AND (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cakepop_vanilla'),
-    'repeated cancellation does not restore twice'
+    (SELECT payload->'items'->0->>'name' = 'Chocolate Chip Cookie'
+        AND (payload->'items'->0->>'unitPriceCents')::int = 200
+     FROM public.orders WHERE id = 'test_snapshot'),
+    'catalog edits do not change historical snapshots'
 );
 
-UPDATE public.orders SET status = 'COMPLETED', payload = jsonb_set(payload, '{status}', '"COMPLETED"')
-WHERE id = 'test_basic';
-DO $$ BEGIN
-    BEGIN
-        PERFORM public.cancel_order_and_restore_inventory('test_basic');
-        RAISE EXCEPTION 'completed order cancellation unexpectedly succeeded';
-    EXCEPTION WHEN OTHERS THEN
-        IF SQLERRM = 'completed order cancellation unexpectedly succeeded' THEN RAISE; END IF;
-    END;
-END $$;
+SELECT public.cancel_order_and_restore_inventory('test_snapshot');
+SELECT public.cancel_order_and_restore_inventory('test_snapshot');
 SELECT pg_temp.assert_true(
-    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
-    'completed order rejection does not restock'
+    (SELECT quantity_on_hand = 3 FROM public.product_inventory WHERE product_id = 'cookie_chocolatechip'),
+    'cancellation restores once and repeated cancellation does not double-restock'
 );
 
 UPDATE public.product_inventory SET quantity_on_hand = 1 WHERE product_id = 'cookie_chocolatechip';


### PR DESCRIPTION
## Summary\n- make POST /api/orders accept only customer/payment input plus product IDs and quantities\n- resolve catalog data, enforce limits, calculate integer-cent totals, reserve stock, and persist snapshots atomically in PostgreSQL\n- separate payment status from fulfillment status and add Zelle\n- return authoritative order information through protected tracking\n- enable RLS and remove browser-role privileges from orders and flavor_requests\n\n## Database\n- add create_authoritative_order RPC\n- preserve atomic current-stock reservation and exact-once cancellation restoration from #6\n- add immutable purchase-time name and price snapshots\n- test with Supabase-style default grants and assert anon/authenticated denial\n\n## Verification\n- npm test: 17 files, 71 tests passed\n- npm run lint: passed\n- npm run build: passed\n- npm run test:db: passed, including concurrent final-unit behavior\n- git diff --check: passed\n\nCloses #7