### PR TITLE
Feature 8 - add authenticated catalog management API

### DIFF
--- a/app/api/admin/categories/[id]/route.ts
+++ b/app/api/admin/categories/[id]/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parseCategoryPatch, updateCategory } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	const { id } = await context.params;
+	return catalogResponse(async () => updateCategory(id, parseCategoryPatch(await readCatalogJson(req))));
+}

--- a/app/api/admin/categories/reorder/route.ts
+++ b/app/api/admin/categories/reorder/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parseCategoryReorder, reorderCategories } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function POST(req: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(async () => {
+		const input = parseCategoryReorder(await readCatalogJson(req));
+		return reorderCategories(input.categoryIds);
+	});
+}

--- a/app/api/admin/categories/route.test.ts
+++ b/app/api/admin/categories/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), create: vi.fn(), list: vi.fn(), update: vi.fn(), reorder: vi.fn() }));
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mocks.auth }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: vi.fn() }));
+vi.mock("@/lib/adminCatalog", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/adminCatalog")>();
+	return {
+		...actual,
+		createCategory: mocks.create,
+		listCategories: mocks.list,
+		updateCategory: mocks.update,
+		reorderCategories: mocks.reorder,
+	};
+});
+
+import { GET, POST } from "./route";
+import { PATCH } from "./[id]/route";
+import { POST as REORDER } from "./reorder/route";
+
+function request(path: string, body: unknown) {
+	return new NextRequest(`http://localhost${path}`, { method: "POST", body: JSON.stringify(body) });
+}
+
+describe("admin category routes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.auth.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+		mocks.create.mockResolvedValue({ id: "generated-category", name: "Cakes" });
+		mocks.list.mockResolvedValue([]);
+		mocks.update.mockResolvedValue({ id: "stable-category", name: "Cupcakes" });
+		mocks.reorder.mockResolvedValue([]);
+	});
+
+	it("requires admin authentication", async () => {
+		mocks.auth.mockResolvedValue({
+			authorized: false,
+			response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+		});
+		expect((await GET()).status).toBe(403);
+		expect((await POST(request("/api/admin/categories", { name: "Cakes" }))).status).toBe(403);
+		expect(mocks.create).not.toHaveBeenCalled();
+	});
+
+	it("creates and renames categories without accepting IDs", async () => {
+		const created = await POST(request("/api/admin/categories", { name: " Cakes " }));
+		const renamed = await PATCH(
+			request("/api/admin/categories/stable-category", { name: " Cupcakes " }),
+			{ params: Promise.resolve({ id: "stable-category" }) }
+		);
+
+		expect(created.status).toBe(201);
+		expect(renamed.status).toBe(200);
+		expect(mocks.create).toHaveBeenCalledWith({ name: "Cakes" });
+		expect(mocks.update).toHaveBeenCalledWith("stable-category", { name: "Cupcakes" });
+	});
+
+	it("forwards a validated full category order", async () => {
+		const response = await REORDER(request("/api/admin/categories/reorder", { categoryIds: ["b", "a"] }));
+
+		expect(response.status).toBe(200);
+		expect(mocks.reorder).toHaveBeenCalledWith(["b", "a"]);
+	});
+});

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { createCategory, listCategories, parseCategoryCreate } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function GET() {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(listCategories);
+}
+
+export async function POST(req: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(async () => createCategory(parseCategoryCreate(await readCatalogJson(req))), 201);
+}

--- a/app/api/admin/products/[id]/archive/route.ts
+++ b/app/api/admin/products/[id]/archive/route.ts
@@ -1,0 +1,10 @@
+import { requireAdmin } from "@/lib/adminAuth";
+import { setProductArchived } from "@/lib/adminCatalog";
+import { catalogResponse } from "@/lib/adminCatalogHttp";
+
+export async function POST(_req: Request, context: { params: Promise<{ id: string }> }) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	const { id } = await context.params;
+	return catalogResponse(() => setProductArchived(id, true));
+}

--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parseProductPatch, updateProduct } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	const { id } = await context.params;
+	return catalogResponse(async () => updateProduct(id, parseProductPatch(await readCatalogJson(req))));
+}

--- a/app/api/admin/products/[id]/unarchive/route.ts
+++ b/app/api/admin/products/[id]/unarchive/route.ts
@@ -1,0 +1,10 @@
+import { requireAdmin } from "@/lib/adminAuth";
+import { setProductArchived } from "@/lib/adminCatalog";
+import { catalogResponse } from "@/lib/adminCatalogHttp";
+
+export async function POST(_req: Request, context: { params: Promise<{ id: string }> }) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	const { id } = await context.params;
+	return catalogResponse(() => setProductArchived(id, false));
+}

--- a/app/api/admin/products/mutations.test.ts
+++ b/app/api/admin/products/mutations.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), update: vi.fn(), archive: vi.fn(), reorder: vi.fn() }));
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mocks.auth }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: vi.fn() }));
+vi.mock("@/lib/adminCatalog", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/adminCatalog")>();
+	return { ...actual, updateProduct: mocks.update, setProductArchived: mocks.archive, reorderProducts: mocks.reorder };
+});
+
+import { PATCH } from "./[id]/route";
+import { POST as ARCHIVE } from "./[id]/archive/route";
+import { POST as UNARCHIVE } from "./[id]/unarchive/route";
+import { POST as REORDER } from "./reorder/route";
+
+const context = { params: Promise.resolve({ id: "stable-id" }) };
+function request(path: string, body: unknown) {
+	return new NextRequest(`http://localhost${path}`, { method: "POST", body: JSON.stringify(body) });
+}
+
+describe("admin product mutations", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.auth.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+		mocks.update.mockResolvedValue({ id: "stable-id", name: "New" });
+		mocks.archive.mockResolvedValue({ id: "stable-id" });
+		mocks.reorder.mockResolvedValue([]);
+	});
+
+	it("PATCH forwards only supplied editable fields and keeps the route identity", async () => {
+		const response = await PATCH(request("/api/admin/products/stable-id", { name: " New " }) as NextRequest, context);
+
+		expect(response.status).toBe(200);
+		expect(mocks.update).toHaveBeenCalledWith("stable-id", { name: "New" });
+	});
+
+	it("rejects attempts to replace product identity", async () => {
+		const response = await PATCH(request("/api/admin/products/stable-id", { id: "replacement" }) as NextRequest, context);
+
+		expect(response.status).toBe(400);
+		expect(mocks.update).not.toHaveBeenCalled();
+	});
+
+	it("archive and unarchive only request archive-state changes and are repeatable", async () => {
+		await ARCHIVE(new Request("http://localhost") , context);
+		await ARCHIVE(new Request("http://localhost") , context);
+		await UNARCHIVE(new Request("http://localhost") , context);
+		await UNARCHIVE(new Request("http://localhost") , context);
+
+		expect(mocks.archive.mock.calls).toEqual([
+			["stable-id", true], ["stable-id", true], ["stable-id", false], ["stable-id", false],
+		]);
+	});
+
+	it("validates and forwards category-scoped ordered product IDs", async () => {
+		const response = await REORDER(request("/api/admin/products/reorder", {
+			categoryId: "cakes",
+			productIds: ["second", "first"],
+		}));
+
+		expect(response.status).toBe(200);
+		expect(mocks.reorder).toHaveBeenCalledWith("cakes", ["second", "first"]);
+	});
+});

--- a/app/api/admin/products/reorder/route.ts
+++ b/app/api/admin/products/reorder/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parseProductReorder, reorderProducts } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function POST(req: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(async () => {
+		const input = parseProductReorder(await readCatalogJson(req));
+		return reorderProducts(input.categoryId, input.productIds);
+	});
+}

--- a/app/api/admin/products/route.test.ts
+++ b/app/api/admin/products/route.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+	create: vi.fn(),
+	list: vi.fn(),
+}));
+
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mocks.auth }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: vi.fn() }));
+vi.mock("@/lib/adminCatalog", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/adminCatalog")>();
+	return { ...actual, createProduct: mocks.create, listProducts: mocks.list };
+});
+
+import { GET, POST } from "./route";
+
+function request(body: unknown) {
+	return new NextRequest("http://localhost/api/admin/products", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("/api/admin/products", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.auth.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+		mocks.list.mockResolvedValue([{ id: "product-1" }]);
+		mocks.create.mockResolvedValue({ id: "generated-id", isArchived: false, quantityOnHand: 0 });
+	});
+
+	it("requires admin authentication for reads and mutations", async () => {
+		mocks.auth.mockResolvedValue({
+			authorized: false,
+			response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+		});
+
+		expect((await GET()).status).toBe(401);
+		expect((await POST(request({ name: "Cake" }))).status).toBe(401);
+		expect(mocks.list).not.toHaveBeenCalled();
+		expect(mocks.create).not.toHaveBeenCalled();
+	});
+
+	it("creates an active zero-stock product from editable fields", async () => {
+		const response = await POST(request({
+			name: "Cake",
+			description: "Good cake",
+			priceCents: 0,
+			categoryId: "cakes",
+			maxPerOrder: 4,
+			image: null,
+		}));
+
+		expect(response.status).toBe(201);
+		expect(mocks.create).toHaveBeenCalledWith({
+			name: "Cake",
+			description: "Good cake",
+			priceCents: 0,
+			categoryId: "cakes",
+			maxPerOrder: 4,
+			image: null,
+		});
+		expect(await response.json()).toMatchObject({ id: "generated-id", isArchived: false, quantityOnHand: 0 });
+	});
+
+	it("returns predictable validation errors", async () => {
+		const response = await POST(request({ name: " ", priceCents: -1, categoryId: "cakes" }));
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "name must be a nonblank string" });
+		expect(mocks.create).not.toHaveBeenCalled();
+	});
+});

--- a/app/api/admin/products/route.ts
+++ b/app/api/admin/products/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { createProduct, listProducts, parseProductCreate } from "@/lib/adminCatalog";
+import { catalogResponse, readCatalogJson } from "@/lib/adminCatalogHttp";
+
+export async function GET() {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(listProducts);
+}
+
+export async function POST(req: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	return catalogResponse(async () => createProduct(parseProductCreate(await readCatalogJson(req))), 201);
+}

--- a/lib/adminCatalog.test.ts
+++ b/lib/adminCatalog.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: vi.fn() }));
+import {
+	CatalogRequestError,
+	parseCategoryCreate,
+	parseCategoryPatch,
+	parseCategoryReorder,
+	parseProductCreate,
+	parseProductPatch,
+	parseProductReorder,
+} from "./adminCatalog";
+
+function expectInvalid(action: () => unknown, message: string) {
+	expect(action).toThrowError(new CatalogRequestError(400, message));
+}
+
+describe("admin catalog validation", () => {
+	it("normalizes a valid product create request", () => {
+		expect(parseProductCreate({
+			name: "  Chocolate Cake  ",
+			description: " Rich ",
+			priceCents: 0,
+			categoryId: " cakes ",
+			maxPerOrder: 6,
+			image: null,
+		})).toEqual({
+			name: "Chocolate Cake",
+			description: "Rich",
+			priceCents: 0,
+			categoryId: "cakes",
+			maxPerOrder: 6,
+			image: null,
+		});
+	});
+
+	it.each([-1, 1.5, Number.MAX_SAFE_INTEGER + 1])("rejects invalid price %s", (priceCents) => {
+		expectInvalid(
+			() => parseProductCreate({ name: "Cake", priceCents, categoryId: "cakes", maxPerOrder: 1 }),
+			"priceCents must be a non-negative safe integer no greater than 2147483647"
+		);
+	});
+
+	it("rejects blank names and invalid max-per-order values", () => {
+		expectInvalid(
+			() => parseProductCreate({ name: "  ", priceCents: 100, categoryId: "cakes", maxPerOrder: 1 }),
+			"name must be a nonblank string"
+		);
+		expectInvalid(
+			() => parseProductCreate({ name: "Cake", priceCents: 100, categoryId: "cakes", maxPerOrder: 0 }),
+			"maxPerOrder must be a positive safe integer no greater than 2147483647"
+		);
+	});
+
+	it("rejects client-controlled product fields", () => {
+		expectInvalid(
+			() => parseProductCreate({ id: "chosen", name: "Cake", priceCents: 100, categoryId: "cakes" }),
+			"Unknown or immutable field: id"
+		);
+		expectInvalid(() => parseProductPatch({ isArchived: true }), "Unknown or immutable field: isArchived");
+	});
+
+	it("keeps omitted PATCH fields omitted while accepting explicit null image", () => {
+		expect(parseProductPatch({ name: " New name ", image: null })).toEqual({
+			name: "New name",
+			image: null,
+		});
+	});
+
+	it("validates image references", () => {
+		expectInvalid(() => parseProductPatch({ image: "  " }), "image must be a nonblank string or null");
+		expect(parseProductPatch({ image: " /img/cake.png " })).toEqual({ image: "/img/cake.png" });
+	});
+
+	it("normalizes category create and patch requests", () => {
+		expect(parseCategoryCreate({ name: " Cakes " })).toEqual({ name: "Cakes" });
+		expect(parseCategoryPatch({ name: " Cupcakes " })).toEqual({ name: "Cupcakes" });
+		expectInvalid(() => parseCategoryCreate({ id: "cakes", name: "Cakes" }), "Unknown or immutable field: id");
+		expectInvalid(() => parseCategoryPatch({ name: " " }), "name must be a nonblank string");
+	});
+
+	it("validates exact, duplicate-free reorder lists", () => {
+		expect(parseProductReorder({ categoryId: " cakes ", productIds: ["a", "b"] })).toEqual({
+			categoryId: "cakes",
+			productIds: ["a", "b"],
+		});
+		expect(parseCategoryReorder({ categoryIds: ["cakes", "cookies"] })).toEqual({
+			categoryIds: ["cakes", "cookies"],
+		});
+		expectInvalid(
+			() => parseProductReorder({ categoryId: "cakes", productIds: ["a", "a"] }),
+			"productIds must not contain duplicates"
+		);
+		expectInvalid(
+			() => parseCategoryReorder({ categoryIds: ["cakes", 2] }),
+			"categoryIds must contain only nonblank strings"
+		);
+	});
+});

--- a/lib/adminCatalog.ts
+++ b/lib/adminCatalog.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from "node:crypto";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+
+export class CatalogRequestError extends Error {
+	constructor(public readonly status: 400 | 404 | 409 | 500, message: string) {
+		super(message);
+		this.name = "CatalogRequestError";
+	}
+}
+
+type ProductInput = {
+	name: string;
+	description: string;
+	priceCents: number;
+	categoryId: string;
+	maxPerOrder: number;
+	image: string | null;
+};
+
+type ProductPatch = Partial<ProductInput>;
+type CategoryInput = { name: string };
+
+type ProductRow = {
+	id: string;
+	category_id: string;
+	name: string;
+	description: string;
+	price_cents: number;
+	image: string | null;
+	max_per_order: number;
+	is_archived: boolean;
+	sort_order: number;
+	created_at: string;
+	updated_at: string;
+};
+
+type CategoryRow = {
+	id: string;
+	name: string;
+	sort_order: number;
+	created_at: string;
+	updated_at: string;
+};
+
+type InventoryRow = { product_id: string; quantity_on_hand: number };
+
+const productFields = "id, category_id, name, description, price_cents, image, max_per_order, is_archived, sort_order, created_at, updated_at";
+const categoryFields = "id, name, sort_order, created_at, updated_at";
+
+function objectBody(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new CatalogRequestError(400, "Request body must be an object");
+	}
+	return value as Record<string, unknown>;
+}
+
+function rejectUnknownFields(body: Record<string, unknown>, allowed: readonly string[]) {
+	const unknown = Object.keys(body).find((key) => !allowed.includes(key));
+	if (unknown) throw new CatalogRequestError(400, `Unknown or immutable field: ${unknown}`);
+}
+
+function nonblankString(value: unknown, field: string): string {
+	if (typeof value !== "string" || !value.trim()) {
+		throw new CatalogRequestError(400, `${field} must be a nonblank string`);
+	}
+	return value.trim();
+}
+
+function description(value: unknown): string {
+	if (typeof value !== "string") throw new CatalogRequestError(400, "description must be a string");
+	return value.trim();
+}
+
+function price(value: unknown): number {
+	if (!Number.isSafeInteger(value) || (value as number) < 0 || (value as number) > POSTGRES_INTEGER_MAX) {
+		throw new CatalogRequestError(400, "priceCents must be a non-negative safe integer no greater than 2147483647");
+	}
+	return value as number;
+}
+
+function maxPerOrder(value: unknown): number {
+	if (!Number.isSafeInteger(value) || (value as number) <= 0 || (value as number) > POSTGRES_INTEGER_MAX) {
+		throw new CatalogRequestError(400, "maxPerOrder must be a positive safe integer no greater than 2147483647");
+	}
+	return value as number;
+}
+
+function imageReference(value: unknown): string | null {
+	if (value === null) return null;
+	if (typeof value !== "string" || !value.trim()) {
+		throw new CatalogRequestError(400, "image must be a nonblank string or null");
+	}
+	return value.trim();
+}
+
+export function parseProductCreate(value: unknown): ProductInput {
+	const body = objectBody(value);
+	rejectUnknownFields(body, ["name", "description", "priceCents", "categoryId", "maxPerOrder", "image"]);
+	return {
+		name: nonblankString(body.name, "name"),
+		description: body.description === undefined ? "" : description(body.description),
+		priceCents: price(body.priceCents),
+		categoryId: nonblankString(body.categoryId, "categoryId"),
+		maxPerOrder: body.maxPerOrder === undefined ? 1 : maxPerOrder(body.maxPerOrder),
+		image: body.image === undefined ? null : imageReference(body.image),
+	};
+}
+
+export function parseProductPatch(value: unknown): ProductPatch {
+	const body = objectBody(value);
+	rejectUnknownFields(body, ["name", "description", "priceCents", "categoryId", "maxPerOrder", "image"]);
+	if (Object.keys(body).length === 0) throw new CatalogRequestError(400, "At least one editable field is required");
+	const result: ProductPatch = {};
+	if (body.name !== undefined) result.name = nonblankString(body.name, "name");
+	if (body.description !== undefined) result.description = description(body.description);
+	if (body.priceCents !== undefined) result.priceCents = price(body.priceCents);
+	if (body.categoryId !== undefined) result.categoryId = nonblankString(body.categoryId, "categoryId");
+	if (body.maxPerOrder !== undefined) result.maxPerOrder = maxPerOrder(body.maxPerOrder);
+	if (body.image !== undefined) result.image = imageReference(body.image);
+	return result;
+}
+
+export function parseCategoryCreate(value: unknown): CategoryInput {
+	const body = objectBody(value);
+	rejectUnknownFields(body, ["name"]);
+	return { name: nonblankString(body.name, "name") };
+}
+
+export function parseCategoryPatch(value: unknown): CategoryInput {
+	return parseCategoryCreate(value);
+}
+
+function orderedIds(value: unknown, field: string): string[] {
+	if (!Array.isArray(value) || value.some((id) => typeof id !== "string" || !id.trim())) {
+		throw new CatalogRequestError(400, `${field} must contain only nonblank strings`);
+	}
+	const ids = value.map((id) => (id as string).trim());
+	if (new Set(ids).size !== ids.length) {
+		throw new CatalogRequestError(400, `${field} must not contain duplicates`);
+	}
+	return ids;
+}
+
+export function parseProductReorder(value: unknown): { categoryId: string; productIds: string[] } {
+	const body = objectBody(value);
+	rejectUnknownFields(body, ["categoryId", "productIds"]);
+	return {
+		categoryId: nonblankString(body.categoryId, "categoryId"),
+		productIds: orderedIds(body.productIds, "productIds"),
+	};
+}
+
+export function parseCategoryReorder(value: unknown): { categoryIds: string[] } {
+	const body = objectBody(value);
+	rejectUnknownFields(body, ["categoryIds"]);
+	return { categoryIds: orderedIds(body.categoryIds, "categoryIds") };
+}
+
+function mapCategory(row: CategoryRow) {
+	return {
+		id: row.id,
+		name: row.name,
+		sortOrder: row.sort_order,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+function mapProduct(row: ProductRow, quantityOnHand: number) {
+	return {
+		id: row.id,
+		categoryId: row.category_id,
+		name: row.name,
+		description: row.description,
+		priceCents: row.price_cents,
+		image: row.image,
+		maxPerOrder: row.max_per_order,
+		isArchived: row.is_archived,
+		sortOrder: row.sort_order,
+		quantityOnHand,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+function databaseFailure(operation: string, error: unknown): never {
+	console.error(`[admin catalog] ${operation} failed`, error);
+	throw new CatalogRequestError(500, "Catalog operation failed");
+}
+
+function uniquenessFailure(operation: string, error: { code?: string } | null): never {
+	if (error?.code === "23505") throw new CatalogRequestError(409, "Category name already exists");
+	return databaseFailure(operation, error);
+}
+
+async function requireCategory(categoryId: string) {
+	const { data, error } = await getSupabaseAdmin()
+		.from("categories")
+		.select("id")
+		.eq("id", categoryId)
+		.maybeSingle();
+	if (error) databaseFailure("category lookup", error);
+	if (!data) throw new CatalogRequestError(404, "Category not found");
+}
+
+async function nextSortOrder(table: "categories" | "products", categoryId?: string): Promise<number> {
+	let query = getSupabaseAdmin().from(table).select("sort_order");
+	if (table === "products" && categoryId) query = query.eq("category_id", categoryId);
+	const { data, error } = await query.order("sort_order", { ascending: false }).limit(1).maybeSingle();
+	if (error) databaseFailure(`${table} position lookup`, error);
+	return ((data as { sort_order?: number } | null)?.sort_order ?? 0) + 10;
+}
+
+export async function listCategories() {
+	const { data, error } = await getSupabaseAdmin()
+		.from("categories")
+		.select(categoryFields)
+		.order("sort_order", { ascending: true })
+		.order("name", { ascending: true })
+		.order("id", { ascending: true });
+	if (error) databaseFailure("list categories", error);
+	return ((data ?? []) as CategoryRow[]).map(mapCategory);
+}
+
+export async function createCategory(input: CategoryInput, generateId: () => string = randomUUID) {
+	const sortOrder = await nextSortOrder("categories");
+	const { data, error } = await getSupabaseAdmin()
+		.from("categories")
+		.insert({ id: generateId(), name: input.name, sort_order: sortOrder })
+		.select(categoryFields)
+		.single();
+	if (error || !data) uniquenessFailure("create category", error);
+	return mapCategory(data as CategoryRow);
+}
+
+export async function updateCategory(id: string, input: CategoryInput) {
+	const { data, error } = await getSupabaseAdmin()
+		.from("categories")
+		.update({ name: input.name })
+		.eq("id", id)
+		.select(categoryFields)
+		.maybeSingle();
+	if (error) uniquenessFailure("update category", error);
+	if (!data) throw new CatalogRequestError(404, "Category not found");
+	return mapCategory(data as CategoryRow);
+}
+
+export async function listProducts() {
+	const supabase = getSupabaseAdmin();
+	const [productsResult, inventoryResult] = await Promise.all([
+		supabase.from("products").select(productFields).order("category_id").order("sort_order").order("name").order("id"),
+		supabase.from("product_inventory").select("product_id, quantity_on_hand"),
+	]);
+	if (productsResult.error) databaseFailure("list products", productsResult.error);
+	if (inventoryResult.error) databaseFailure("list product inventory", inventoryResult.error);
+	const inventory = new Map(((inventoryResult.data ?? []) as InventoryRow[]).map((row) => [row.product_id, row.quantity_on_hand]));
+	return ((productsResult.data ?? []) as ProductRow[]).map((row) => mapProduct(row, inventory.get(row.id) ?? 0));
+}
+
+async function getProduct(id: string) {
+	const supabase = getSupabaseAdmin();
+	const [productResult, inventoryResult] = await Promise.all([
+		supabase.from("products").select(productFields).eq("id", id).maybeSingle(),
+		supabase.from("product_inventory").select("quantity_on_hand").eq("product_id", id).maybeSingle(),
+	]);
+	if (productResult.error) databaseFailure("product lookup", productResult.error);
+	if (!productResult.data) throw new CatalogRequestError(404, "Product not found");
+	if (inventoryResult.error) databaseFailure("product inventory lookup", inventoryResult.error);
+	return mapProduct(productResult.data as ProductRow, (inventoryResult.data as { quantity_on_hand?: number } | null)?.quantity_on_hand ?? 0);
+}
+
+export async function createProduct(input: ProductInput, generateId: () => string = randomUUID) {
+	await requireCategory(input.categoryId);
+	const sortOrder = await nextSortOrder("products", input.categoryId);
+	const id = generateId();
+	const { error } = await getSupabaseAdmin().from("products").insert({
+		id,
+		category_id: input.categoryId,
+		name: input.name,
+		description: input.description,
+		price_cents: input.priceCents,
+		image: input.image,
+		max_per_order: input.maxPerOrder,
+		is_archived: false,
+		sort_order: sortOrder,
+	});
+	if (error) databaseFailure("create product", error);
+	return getProduct(id);
+}
+
+export async function updateProduct(id: string, input: ProductPatch) {
+	const { data: existing, error: lookupError } = await getSupabaseAdmin()
+		.from("products")
+		.select("id, category_id")
+		.eq("id", id)
+		.maybeSingle();
+	if (lookupError) databaseFailure("product lookup", lookupError);
+	if (!existing) throw new CatalogRequestError(404, "Product not found");
+
+	const update: Record<string, unknown> = {};
+	if (input.name !== undefined) update.name = input.name;
+	if (input.description !== undefined) update.description = input.description;
+	if (input.priceCents !== undefined) update.price_cents = input.priceCents;
+	if (input.maxPerOrder !== undefined) update.max_per_order = input.maxPerOrder;
+	if (input.image !== undefined) update.image = input.image;
+	if (input.categoryId !== undefined && input.categoryId !== existing.category_id) {
+		await requireCategory(input.categoryId);
+		update.category_id = input.categoryId;
+		update.sort_order = await nextSortOrder("products", input.categoryId);
+	}
+
+	if (Object.keys(update).length > 0) {
+		const { error } = await getSupabaseAdmin().from("products").update(update).eq("id", id);
+		if (error) databaseFailure("update product", error);
+	}
+	return getProduct(id);
+}
+
+export async function setProductArchived(id: string, isArchived: boolean) {
+	const { data, error } = await getSupabaseAdmin()
+		.from("products")
+		.update({ is_archived: isArchived })
+		.eq("id", id)
+		.select("id")
+		.maybeSingle();
+	if (error) databaseFailure(isArchived ? "archive product" : "unarchive product", error);
+	if (!data) throw new CatalogRequestError(404, "Product not found");
+	return getProduct(id);
+}
+
+function reorderFailure(error: { message?: string } | null): never {
+	if (error?.message?.includes("CATALOG_CATEGORY_NOT_FOUND")) throw new CatalogRequestError(404, "Category not found");
+	if (error?.message?.includes("CATALOG_INVALID_REORDER")) throw new CatalogRequestError(400, "Reorder list must contain exactly the applicable IDs");
+	return databaseFailure("reorder", error);
+}
+
+export async function reorderProducts(categoryId: string, productIds: string[]) {
+	const { error } = await getSupabaseAdmin().rpc("reorder_category_products", {
+		p_category_id: categoryId,
+		p_product_ids: productIds,
+	});
+	if (error) reorderFailure(error);
+	return listProducts().then((products) => products.filter((product) => product.categoryId === categoryId));
+}
+
+export async function reorderCategories(categoryIds: string[]) {
+	const { error } = await getSupabaseAdmin().rpc("reorder_catalog_categories", {
+		p_category_ids: categoryIds,
+	});
+	if (error) reorderFailure(error);
+	return listCategories();
+}

--- a/lib/adminCatalogHttp.ts
+++ b/lib/adminCatalogHttp.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CatalogRequestError } from "@/lib/adminCatalog";
+
+export async function readCatalogJson(req: NextRequest): Promise<unknown> {
+	try {
+		return await req.json();
+	} catch {
+		throw new CatalogRequestError(400, "Invalid JSON body");
+	}
+}
+
+export async function catalogResponse<T>(operation: () => Promise<T>, status = 200) {
+	try {
+		return NextResponse.json(await operation(), { status });
+	} catch (error) {
+		if (error instanceof CatalogRequestError) {
+			return NextResponse.json({ error: error.message }, { status: error.status });
+		}
+		console.error("[admin catalog] unexpected failure", error);
+		return NextResponse.json({ error: "Catalog operation failed" }, { status: 500 });
+	}
+}

--- a/lib/adminCatalogService.test.ts
+++ b/lib/adminCatalogService.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFrom, mockGetSupabaseAdmin } = vi.hoisted(() => ({
+	mockFrom: vi.fn(),
+	mockGetSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: mockGetSupabaseAdmin }));
+
+import {
+	CatalogRequestError,
+	createCategory,
+	createProduct,
+	setProductArchived,
+	updateProduct,
+} from "./adminCatalog";
+
+const productRow = {
+	id: "generated-product-id",
+	category_id: "cakes",
+	name: "Cake",
+	description: "",
+	price_cents: 0,
+	image: null,
+	max_per_order: 1,
+	is_archived: false,
+	sort_order: 30,
+	created_at: "created",
+	updated_at: "updated",
+};
+
+describe("admin catalog persistence", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+	});
+
+	it("generates product identity, inserts active state, and relies on trigger-created inventory", async () => {
+		let productCall = 0;
+		const insert = vi.fn().mockResolvedValue({ error: null });
+		mockFrom.mockImplementation((table: string) => {
+			if (table === "categories") {
+				return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: "cakes" }, error: null }) }) }) };
+			}
+			if (table === "product_inventory") {
+				return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { quantity_on_hand: 0 }, error: null }) }) }) };
+			}
+			productCall++;
+			if (productCall === 1) {
+				return { select: () => ({ eq: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: { sort_order: 20 }, error: null }) }) }) }) }) };
+			}
+			if (productCall === 2) return { insert };
+			return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: productRow, error: null }) }) }) };
+		});
+
+		const created = await createProduct({
+			name: "Cake", description: "", priceCents: 0, categoryId: "cakes", maxPerOrder: 1, image: null,
+		}, () => "generated-product-id");
+
+		expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+			id: "generated-product-id",
+			is_archived: false,
+			sort_order: 30,
+		}));
+		expect(mockFrom.mock.calls.filter(([table]) => table === "product_inventory")).toHaveLength(1);
+		expect(created).toMatchObject({ id: "generated-product-id", isArchived: false, quantityOnHand: 0 });
+	});
+
+	it("generates category identity", async () => {
+		const insert = vi.fn().mockReturnValue({
+			select: () => ({ single: async () => ({
+				data: { id: "generated-category-id", name: "Cakes", sort_order: 10, created_at: "created", updated_at: "updated" },
+				error: null,
+			}) }),
+		});
+		let call = 0;
+		mockFrom.mockImplementation(() => {
+			call++;
+			if (call === 1) return { select: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }) };
+			return { insert };
+		});
+
+		const created = await createCategory({ name: "Cakes" }, () => "generated-category-id");
+
+		expect(insert).toHaveBeenCalledWith({ id: "generated-category-id", name: "Cakes", sort_order: 10 });
+		expect(created.id).toBe("generated-category-id");
+	});
+
+	it("maps duplicate category names to a safe conflict", async () => {
+		let call = 0;
+		mockFrom.mockImplementation(() => {
+			call++;
+			if (call === 1) return { select: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }) }) };
+			return {
+				insert: () => ({ select: () => ({ single: async () => ({ data: null, error: { code: "23505", message: "raw database detail" } }) }) }),
+			};
+		});
+
+		await expect(createCategory({ name: "Cakes" }, () => "generated-category-id")).rejects.toEqual(
+			new CatalogRequestError(409, "Category name already exists")
+		);
+	});
+
+	it("rejects an unknown product without attempting an update", async () => {
+		const update = vi.fn();
+		mockFrom.mockReturnValue({
+			select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+			update,
+		});
+
+		await expect(updateProduct("unknown", { name: "New" })).rejects.toEqual(
+			new CatalogRequestError(404, "Product not found")
+		);
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("moves a product without changing identity, inventory, or archive state", async () => {
+		const update = vi.fn();
+		let productCall = 0;
+		mockFrom.mockImplementation((table: string) => {
+			if (table === "categories") return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: "cookies" }, error: null }) }) }) };
+			if (table === "product_inventory") return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { quantity_on_hand: 7 }, error: null }) }) }) };
+			productCall++;
+			if (productCall === 1) return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: "generated-product-id", category_id: "cakes" }, error: null }) }) }) };
+			if (productCall === 2) return { select: () => ({ eq: () => ({ order: () => ({ limit: () => ({ maybeSingle: async () => ({ data: { sort_order: 40 }, error: null }) }) }) }) }) };
+			if (productCall === 3) {
+				return { update: (values: unknown) => { update(values); return { eq: async () => ({ error: null }) }; } };
+			}
+			return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { ...productRow, category_id: "cookies", is_archived: true }, error: null }) }) }) };
+		});
+
+		const moved = await updateProduct("generated-product-id", { categoryId: "cookies", name: "Moved" });
+
+		expect(update).toHaveBeenCalledWith({ name: "Moved", category_id: "cookies", sort_order: 50 });
+		expect(moved).toMatchObject({ id: "generated-product-id", categoryId: "cookies", isArchived: true, quantityOnHand: 7 });
+	});
+
+	it("archive writes only archive state", async () => {
+		const update = vi.fn();
+		let productCall = 0;
+		mockFrom.mockImplementation((table: string) => {
+			if (table === "product_inventory") return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { quantity_on_hand: 9 }, error: null }) }) }) };
+			productCall++;
+			if (productCall === 1) return { update: (values: unknown) => { update(values); return { eq: () => ({ select: () => ({ maybeSingle: async () => ({ data: { id: productRow.id }, error: null }) }) }) }; } };
+			return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { ...productRow, is_archived: true }, error: null }) }) }) };
+		});
+
+		const archived = await setProductArchived(productRow.id, true);
+
+		expect(update).toHaveBeenCalledWith({ is_archived: true });
+		expect(archived).toMatchObject({ id: productRow.id, isArchived: true, quantityOnHand: 9 });
+	});
+});

--- a/lib/menuCatalog.test.ts
+++ b/lib/menuCatalog.test.ts
@@ -43,11 +43,28 @@ describe("buildSections", () => {
 				{ id: "z", name: "Z", sortOrder: 3 },
 				{ id: "a", name: "A", sortOrder: 1 },
 			],
-			items: [],
+			items: [
+				{ id: "1", name: "Z item", categoryId: "z", basePrice: 1, availability: { inStock: true } },
+				{ id: "2", name: "A item", categoryId: "a", basePrice: 1, availability: { inStock: true } },
+			],
 		};
 		const sections = buildSections(catalog);
 		expect(sections[0].category.id).toBe("a");
 		expect(sections[1].category.id).toBe("z");
+	});
+
+	it("omits categories with no current products", () => {
+		const catalog: MenuCatalog = {
+			categories: [
+				{ id: "empty", name: "Empty", sortOrder: 1 },
+				{ id: "current", name: "Current", sortOrder: 2 },
+			],
+			items: [
+				{ id: "1", name: "Cake", categoryId: "current", basePrice: 1, availability: { inStock: false } },
+			],
+		};
+
+		expect(buildSections(catalog).map((section) => section.category.id)).toEqual(["current"]);
 	});
 
 	it("sorts products by sortOrder, then name", () => {

--- a/lib/menuCatalog.ts
+++ b/lib/menuCatalog.ts
@@ -89,7 +89,7 @@ export function buildSections(catalog:MenuCatalog): Section[] {
 			return a.id.localeCompare(b.id);
 		});
         return {category:cat, items};
-    });
+    }).filter((section) => section.items.length > 0);
 
     return sections;
 }

--- a/scripts/test-inventory-db.sh
+++ b/scripts/test-inventory-db.sh
@@ -32,8 +32,10 @@ SQL
 for migration in supabase/migrations/*.sql; do
     docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" < "$migration" >/dev/null
 done
-docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
-    < supabase/tests/current_product_inventory.sql >/dev/null
+for test_file in supabase/tests/*.sql; do
+    docker exec -i "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
+        < "$test_file" >/dev/null
+done
 
 reservation_one="SELECT public.create_authoritative_order('race_1','track_race_1','{\"name\":\"Race One\",\"email\":\"one@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"
 reservation_two="SELECT public.create_authoritative_order('race_2','track_race_2','{\"name\":\"Race Two\",\"email\":\"two@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"

--- a/supabase/migrations/20260909210000_admin_catalog_reordering.sql
+++ b/supabase/migrations/20260909210000_admin_catalog_reordering.sql
@@ -1,0 +1,69 @@
+CREATE FUNCTION public.reorder_category_products(p_category_id TEXT, p_product_ids TEXT[])
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM public.categories WHERE id = p_category_id) THEN
+        RAISE EXCEPTION 'CATALOG_CATEGORY_NOT_FOUND';
+    END IF;
+
+    IF p_product_ids IS NULL
+        OR (SELECT count(DISTINCT id) FROM unnest(p_product_ids) AS id) <> cardinality(p_product_ids)
+        OR EXISTS (
+            SELECT 1
+            FROM unnest(p_product_ids) AS requested(id)
+            LEFT JOIN public.products AS product
+                ON product.id = requested.id AND product.category_id = p_category_id
+            WHERE product.id IS NULL
+        )
+        OR (SELECT count(*) FROM public.products WHERE category_id = p_category_id) <> cardinality(p_product_ids)
+    THEN
+        RAISE EXCEPTION 'CATALOG_INVALID_REORDER';
+    END IF;
+
+    UPDATE public.products AS product
+    SET sort_order = requested.position * 10
+    FROM unnest(p_product_ids) WITH ORDINALITY AS requested(id, position)
+    WHERE product.id = requested.id
+      AND product.category_id = p_category_id;
+END;
+$$;
+
+CREATE FUNCTION public.reorder_catalog_categories(p_category_ids TEXT[])
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_category_ids IS NULL
+        OR (SELECT count(DISTINCT id) FROM unnest(p_category_ids) AS id) <> cardinality(p_category_ids)
+        OR EXISTS (
+            SELECT 1
+            FROM unnest(p_category_ids) AS requested(id)
+            LEFT JOIN public.categories AS category ON category.id = requested.id
+            WHERE category.id IS NULL
+        )
+        OR (SELECT count(*) FROM public.categories) <> cardinality(p_category_ids)
+    THEN
+        RAISE EXCEPTION 'CATALOG_INVALID_REORDER';
+    END IF;
+
+    UPDATE public.categories AS category
+    SET sort_order = requested.position * 10
+    FROM unnest(p_category_ids) WITH ORDINALITY AS requested(id, position)
+    WHERE category.id = requested.id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reorder_category_products(TEXT, TEXT[]) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reorder_catalog_categories(TEXT[]) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reorder_category_products(TEXT, TEXT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.reorder_catalog_categories(TEXT[]) TO service_role;
+
+COMMENT ON FUNCTION public.reorder_category_products(TEXT, TEXT[])
+IS 'Atomically normalizes one category full product order from an ordered ID list.';
+COMMENT ON FUNCTION public.reorder_catalog_categories(TEXT[])
+IS 'Atomically normalizes the full category order from an ordered ID list.';

--- a/supabase/tests/admin_catalog.sql
+++ b/supabase/tests/admin_catalog.sql
@@ -1,0 +1,133 @@
+CREATE FUNCTION pg_temp.assert_catalog(condition BOOLEAN, message TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+BEGIN
+    IF NOT condition THEN RAISE EXCEPTION 'assertion failed: %', message; END IF;
+END;
+$$;
+
+SELECT pg_temp.assert_catalog(
+    EXISTS (SELECT 1 FROM public.products WHERE id = 'cakepop_chocolate')
+    AND EXISTS (SELECT 1 FROM public.categories WHERE id = 'cakepops'),
+    'legacy product and category IDs remain unchanged'
+);
+
+INSERT INTO public.categories (id, name, sort_order)
+VALUES
+    ('00000000-0000-4000-8000-000000000001', 'Admin Test One', 100),
+    ('00000000-0000-4000-8000-000000000002', 'Admin Test Two', 110);
+
+INSERT INTO public.products (id, category_id, name, price_cents, max_per_order, sort_order)
+VALUES
+    ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000001', 'Duplicate Name', 0, 1, 10),
+    ('00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000001', 'Duplicate Name', 100, 2, 20);
+
+SELECT pg_temp.assert_catalog(
+    (SELECT count(*) = 2 FROM public.products WHERE name = 'Duplicate Name'),
+    'duplicate product names are allowed'
+);
+SELECT pg_temp.assert_catalog(
+    (SELECT quantity_on_hand = 0 FROM public.product_inventory WHERE product_id = '00000000-0000-4000-8000-000000000011')
+    AND (SELECT is_archived = false FROM public.products WHERE id = '00000000-0000-4000-8000-000000000011'),
+    'new product trigger creates zero inventory and product defaults active'
+);
+
+UPDATE public.product_inventory
+SET quantity_on_hand = 7
+WHERE product_id = '00000000-0000-4000-8000-000000000011';
+UPDATE public.products
+SET category_id = '00000000-0000-4000-8000-000000000002', is_archived = true
+WHERE id = '00000000-0000-4000-8000-000000000011';
+UPDATE public.products SET is_archived = false WHERE id = '00000000-0000-4000-8000-000000000011';
+SELECT public.create_authoritative_order(
+    'admin_catalog_history',
+    'track_admin_catalog_history',
+    '{"name":"Catalog Test","email":"catalog@example.com"}'::jsonb,
+    '{"method":"cash"}'::jsonb,
+    '[{"productId":"00000000-0000-4000-8000-000000000011","quantity":1}]'::jsonb
+);
+INSERT INTO public.flavor_requests (item_id, customer_email)
+VALUES ('00000000-0000-4000-8000-000000000011', 'catalog@example.com');
+UPDATE public.products SET is_archived = true WHERE id = '00000000-0000-4000-8000-000000000011';
+UPDATE public.products SET is_archived = false WHERE id = '00000000-0000-4000-8000-000000000011';
+UPDATE public.products SET is_archived = false WHERE id = '00000000-0000-4000-8000-000000000011';
+
+SELECT pg_temp.assert_catalog(
+    (SELECT category_id = '00000000-0000-4000-8000-000000000002'
+        AND is_archived = false
+     FROM public.products WHERE id = '00000000-0000-4000-8000-000000000011')
+    AND (SELECT quantity_on_hand = 6
+        FROM public.product_inventory WHERE product_id = '00000000-0000-4000-8000-000000000011')
+    AND (SELECT payload->'items'->0->>'productId' = '00000000-0000-4000-8000-000000000011'
+        FROM public.orders WHERE id = 'admin_catalog_history')
+    AND EXISTS (
+        SELECT 1 FROM public.flavor_requests
+        WHERE item_id = '00000000-0000-4000-8000-000000000011'
+          AND customer_email = 'catalog@example.com'
+    ),
+    'move and idempotent archive transitions preserve identity, inventory, orders, and flavor requests'
+);
+
+SELECT public.reorder_category_products(
+    '00000000-0000-4000-8000-000000000001',
+    ARRAY['00000000-0000-4000-8000-000000000012']
+);
+SELECT pg_temp.assert_catalog(
+    (SELECT sort_order = 10 FROM public.products WHERE id = '00000000-0000-4000-8000-000000000012'),
+    'product reorder normalizes positions'
+);
+
+DO $$
+DECLARE
+    before_order INTEGER;
+BEGIN
+    SELECT sort_order INTO before_order FROM public.products WHERE id = '00000000-0000-4000-8000-000000000012';
+    BEGIN
+        PERFORM public.reorder_category_products(
+            '00000000-0000-4000-8000-000000000001',
+            ARRAY['00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000012']
+        );
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'CATALOG_INVALID_REORDER%' THEN RAISE; END IF;
+    END;
+    IF (SELECT sort_order FROM public.products WHERE id = '00000000-0000-4000-8000-000000000012') <> before_order THEN
+        RAISE EXCEPTION 'failed product reorder changed persisted order';
+    END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+    reversed_ids TEXT[];
+BEGIN
+    SELECT array_agg(id ORDER BY id DESC) INTO reversed_ids FROM public.categories;
+    PERFORM public.reorder_catalog_categories(reversed_ids);
+    IF EXISTS (
+        SELECT 1
+        FROM unnest(reversed_ids) WITH ORDINALITY AS expected(id, position)
+        JOIN public.categories AS category ON category.id = expected.id
+        WHERE category.sort_order <> expected.position * 10
+    ) THEN
+        RAISE EXCEPTION 'category reorder did not persist deterministically';
+    END IF;
+END;
+$$;
+
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.reorder_category_products(
+            '00000000-0000-4000-8000-000000000001',
+            ARRAY['00000000-0000-4000-8000-000000000011']
+        );
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'CATALOG_INVALID_REORDER%' THEN RAISE; END IF;
+    END;
+END $$;
+
+SELECT pg_temp.assert_catalog(
+    NOT has_function_privilege('anon', 'public.reorder_category_products(text,text[])', 'EXECUTE')
+    AND NOT has_function_privilege('authenticated', 'public.reorder_category_products(text,text[])', 'EXECUTE')
+    AND has_function_privilege('service_role', 'public.reorder_category_products(text,text[])', 'EXECUTE'),
+    'reorder functions are server-only'
+);


### PR DESCRIPTION
## Summary
- add authenticated product and category management route handlers using the existing requireAdmin flow
- generate immutable UUIDs server-side and preserve trigger-managed current inventory
- add atomic ordered-ID reorder RPCs and hide empty current-menu categories
- add API, unit, and PostgreSQL integration coverage

## Verification
- npm test: 22 files passed, 98 tests passed
- npm run test:db: passed
- npm run lint: passed
- npm run build: passed
- git diff --check: passed

Closes #8