### PR TITLE
Feature 9 - add mobile-first menu management

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,64 +1,13 @@
-import Link from "next/link";
-import {
-	CalendarNavIcon,
-	ChatNavIcon,
-	OrdersNavIcon,
-	SettingsNavIcon,
-} from "@/components/icons/navIcons";
-import { LogoutButton } from "@/components/admin/LogoutButton";
+import { AdminNavigation } from "@/components/admin/AdminNavigation";
 
 /**
  * Admin layout: provides bakery-themed navigation for all admin pages.
  * Inherits fonts and theme from root layout.
  */
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-	const linkClass =
-		"inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-cocoa transition-colors hover:bg-cream/80 hover:text-caramel";
-
 	return (
 		<div className="min-h-[60vh]">
-			<nav
-				className="border-b border-amber-200/80 bg-gradient-to-r from-wheat via-peach-mist/60 to-parchment"
-				aria-label="Admin"
-			>
-				<div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-					<div className="flex flex-wrap items-center gap-2 sm:gap-4">
-						<Link
-							href="/admin/orders"
-							className="font-display text-lg font-semibold text-cocoa transition-colors hover:text-caramel"
-						>
-							Admin
-						</Link>
-						<div className="flex flex-wrap gap-1 sm:gap-2">
-							<Link href="/admin/orders" className={linkClass}>
-								<OrdersNavIcon className="text-caramel" size={18} />
-								Orders
-							</Link>
-							<Link href="/admin/availability" className={linkClass}>
-								<CalendarNavIcon className="text-caramel" size={18} />
-								Availability
-							</Link>
-							<Link href="/admin/flavor-requests" className={linkClass}>
-								<ChatNavIcon className="text-caramel" size={18} />
-								Flavor requests
-							</Link>
-							<Link href="/admin/settings" className={linkClass}>
-								<SettingsNavIcon className="text-caramel" size={18} />
-								Settings
-							</Link>
-						</div>
-					</div>
-					<div className="flex items-center gap-4">
-						<LogoutButton />
-						<Link
-							href="/"
-							className="text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
-						>
-							← Back to site
-						</Link>
-					</div>
-				</div>
-			</nav>
+			<AdminNavigation />
 			{children}
 		</div>
 	);

--- a/app/admin/menu/page.tsx
+++ b/app/admin/menu/page.tsx
@@ -1,0 +1,9 @@
+import { AdminMenu } from "@/components/admin/menu/AdminMenu";
+
+export default function AdminMenuPage() {
+	return (
+		<main className="mx-auto w-full max-w-3xl px-0 py-4 sm:px-4 sm:py-6">
+			<AdminMenu />
+		</main>
+	);
+}

--- a/app/api/admin/inventory/adjust/route.test.ts
+++ b/app/api/admin/inventory/adjust/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { mockRequireAdmin, mockAdjustProductInventory } = vi.hoisted(() => ({
+	mockRequireAdmin: vi.fn(),
+	mockAdjustProductInventory: vi.fn(),
+}));
+
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/inventoryUpsert", () => ({ adjustProductInventory: mockAdjustProductInventory }));
+
+import { POST } from "./route";
+
+function request(body: unknown) {
+	return new NextRequest("http://localhost/api/admin/inventory/adjust", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("POST /api/admin/inventory/adjust", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireAdmin.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+		mockAdjustProductInventory.mockResolvedValue({
+			ok: true,
+			data: { product_id: "cake", quantity_on_hand: 6 },
+		});
+	});
+
+	it("requires admin authentication", async () => {
+		mockRequireAdmin.mockResolvedValue({
+			authorized: false,
+			response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+		});
+
+		const response = await POST(request({ product_id: "cake", delta: 1 }));
+
+		expect(response.status).toBe(401);
+		expect(mockAdjustProductInventory).not.toHaveBeenCalled();
+	});
+
+	it.each([1, -1, 12])("atomically applies delta %s and returns authoritative stock", async (delta) => {
+		const response = await POST(request({ product_id: "cake", delta }));
+
+		expect(response.status).toBe(200);
+		expect(mockAdjustProductInventory).toHaveBeenCalledWith("cake", delta);
+		expect(await response.json()).toEqual({ product_id: "cake", quantity_on_hand: 6 });
+	});
+
+	it.each([-1.5, Number.NaN, 2_147_483_648])("rejects invalid delta %s", async (delta) => {
+		const response = await POST(request({ product_id: "cake", delta }));
+
+		expect(response.status).toBe(400);
+		expect(mockAdjustProductInventory).not.toHaveBeenCalled();
+	});
+
+	it("returns a nontechnical conflict when decrement would go below zero", async () => {
+		mockAdjustProductInventory.mockResolvedValue({
+			ok: false,
+			status: 409,
+			error: "There is not enough available to make that change.",
+		});
+
+		const response = await POST(request({ product_id: "cake", delta: -1 }));
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({ error: "There is not enough available to make that change." });
+	});
+});

--- a/app/api/admin/inventory/adjust/route.ts
+++ b/app/api/admin/inventory/adjust/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { adjustProductInventory } from "@/lib/inventoryUpsert";
+
+export async function POST(request: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+
+	const body = await request.json().catch(() => null);
+	const productId = body?.product_id;
+	const delta = body?.delta;
+	if (typeof productId !== "string" || !productId.trim()) {
+		return NextResponse.json({ error: "Choose a product to update." }, { status: 400 });
+	}
+	if (!Number.isSafeInteger(delta) || delta < -2_147_483_647 || delta > 2_147_483_647) {
+		return NextResponse.json({ error: "The amount must be a whole number." }, { status: 400 });
+	}
+
+	const result = await adjustProductInventory(productId.trim(), delta);
+	if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
+	return NextResponse.json(result.data);
+}

--- a/components/admin/AdminNavigation.tsx
+++ b/components/admin/AdminNavigation.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { LogoutButton } from "@/components/admin/LogoutButton";
+import {
+	ChatNavIcon,
+	MenuNavIcon,
+	OrdersNavIcon,
+	PastFlavorsNavIcon,
+} from "@/components/icons/navIcons";
+
+const links = [
+	{ href: "/admin/orders", label: "Orders", Icon: OrdersNavIcon },
+	{ href: "/admin/menu", label: "Menu", Icon: MenuNavIcon },
+	{ href: "/admin/flavor-requests", label: "Demand", Icon: ChatNavIcon },
+	{ href: "/admin/menu?view=past", label: "Past Flavors", Icon: PastFlavorsNavIcon },
+];
+
+function NavigationLinks() {
+	return (
+		<>
+			{links.map(({ href, label, Icon }) => (
+				<Link
+					key={href}
+					href={href}
+					className="inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-cocoa transition-colors hover:bg-cream/80 hover:text-caramel"
+				>
+					<Icon className="text-caramel" size={18} />
+					{label}
+				</Link>
+			))}
+		</>
+	);
+}
+
+export function AdminNavigation() {
+	return (
+		<nav
+			className="border-b border-amber-200/80 bg-gradient-to-r from-wheat via-peach-mist/60 to-parchment"
+			aria-label="Admin"
+		>
+			<div className="mx-auto max-w-5xl px-4 py-3 sm:flex sm:items-center sm:justify-between sm:px-6">
+				<div className="flex items-center justify-between gap-3">
+					<Link
+						href="/admin/orders"
+						className="font-display text-lg font-semibold text-cocoa transition-colors hover:text-caramel"
+					>
+						Admin
+					</Link>
+					<details className="relative sm:hidden">
+						<summary className="flex min-h-11 cursor-pointer list-none items-center rounded-button border border-crust bg-cream px-4 font-medium text-cocoa marker:content-none">
+							Navigation
+						</summary>
+						<div className="absolute right-0 z-30 mt-2 grid min-w-52 gap-1 rounded-card border border-crust bg-cream p-2 shadow-card">
+							<NavigationLinks />
+							<div className="border-t border-crust px-3 pt-2"><LogoutButton /></div>
+						</div>
+					</details>
+				</div>
+				<div className="hidden items-center gap-1 sm:flex">
+					<NavigationLinks />
+					<div className="ml-2 border-l border-crust pl-3"><LogoutButton /></div>
+				</div>
+			</div>
+		</nav>
+	);
+}

--- a/components/admin/LogoutButton.tsx
+++ b/components/admin/LogoutButton.tsx
@@ -10,7 +10,7 @@ export function LogoutButton() {
 		<form action="/auth/signout" method="post">
 			<button
 				type="submit"
-				className="text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
+				className="inline-flex min-h-11 items-center text-sm text-caramel/90 transition-colors hover:text-caramel hover:underline"
 			>
 				Logout
 			</button>

--- a/components/admin/menu/AdminMenu.tsx
+++ b/components/admin/menu/AdminMenu.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { handleAdminAuthFailure } from "@/lib/adminResponse";
+import {
+	ProductActionQueue,
+	splitMenuProducts,
+	type AdminMenuCategory,
+	type AdminMenuProduct,
+} from "@/lib/adminMenu";
+import { MenuProductCard, PastFlavorCard } from "./MenuProductCard";
+import { ProductForm } from "./ProductForm";
+
+type View = "current" | "past";
+
+async function responseError(response: Response, fallback: string) {
+	const authError = handleAdminAuthFailure(response);
+	if (authError) return authError;
+	const body = await response.json().catch(() => ({}));
+	return (body as { error?: string }).error ?? fallback;
+}
+
+export function AdminMenu() {
+	const [products, setProducts] = useState<AdminMenuProduct[]>([]);
+	const [categories, setCategories] = useState<AdminMenuCategory[]>([]);
+	const [view, setView] = useState<View>("current");
+	const [loading, setLoading] = useState(true);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [productErrors, setProductErrors] = useState<Record<string, string>>({});
+	const [pending, setPending] = useState<Record<string, number>>({});
+	const [editing, setEditing] = useState<AdminMenuProduct | null | undefined>(undefined);
+	const queue = useRef(new ProductActionQueue());
+
+	async function loadMenu() {
+		setLoading(true);
+		setLoadError(null);
+		try {
+			const [productsResponse, categoriesResponse] = await Promise.all([
+				fetch("/api/admin/products"),
+				fetch("/api/admin/categories"),
+			]);
+			if (!productsResponse.ok) throw new Error(await responseError(productsResponse, "Menu could not be loaded."));
+			if (!categoriesResponse.ok) throw new Error(await responseError(categoriesResponse, "Categories could not be loaded."));
+			const [productData, categoryData] = await Promise.all([productsResponse.json(), categoriesResponse.json()]);
+			setProducts(Array.isArray(productData) ? productData : []);
+			setCategories(Array.isArray(categoryData) ? categoryData : []);
+		} catch (error) {
+			setLoadError(error instanceof Error ? error.message : "Menu could not be loaded. Please try again.");
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	useEffect(() => {
+		if (new URLSearchParams(window.location.search).get("view") === "past") setView("past");
+		void loadMenu();
+	}, []);
+
+	function chooseView(nextView: View) {
+		setView(nextView);
+		window.history.replaceState(null, "", nextView === "past" ? "/admin/menu?view=past" : "/admin/menu");
+	}
+
+	function updateProduct(saved: AdminMenuProduct) {
+		setProducts((current) => current.map((product) => product.id === saved.id ? saved : product));
+	}
+
+	async function refreshProduct(productId: string) {
+		const response = await fetch("/api/admin/products");
+		if (!response.ok) return;
+		const fresh = (await response.json()) as AdminMenuProduct[];
+		const product = fresh.find((candidate) => candidate.id === productId);
+		if (product) updateProduct(product);
+	}
+
+	function adjust(productId: string, delta: number) {
+		setProductErrors((current) => ({ ...current, [productId]: "" }));
+		setPending((current) => ({ ...current, [productId]: (current[productId] ?? 0) + 1 }));
+		void queue.current.enqueue(productId, async () => {
+			try {
+				const response = await fetch("/api/admin/inventory/adjust", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ product_id: productId, delta }),
+				});
+				if (!response.ok) {
+					const message = await responseError(response, "Quantity could not be updated. Please try again.");
+					await refreshProduct(productId);
+					setProductErrors((current) => ({ ...current, [productId]: message }));
+					return;
+				}
+				const inventory = await response.json() as { quantity_on_hand: number };
+				setProducts((current) => current.map((product) => product.id === productId
+					? { ...product, quantityOnHand: inventory.quantity_on_hand }
+					: product));
+				setProductErrors((current) => ({ ...current, [productId]: "" }));
+			} catch {
+				await refreshProduct(productId);
+				setProductErrors((current) => ({ ...current, [productId]: "Quantity could not be updated. Check your connection and try again." }));
+			} finally {
+				setPending((current) => ({ ...current, [productId]: Math.max(0, (current[productId] ?? 1) - 1) }));
+			}
+		});
+	}
+
+	async function saveProduct(values: { name: string; description: string; priceCents: number; categoryId: string; maxPerOrder: number }) {
+		const product = editing ?? null;
+		const response = await fetch(product ? `/api/admin/products/${encodeURIComponent(product.id)}` : "/api/admin/products", {
+			method: product ? "PATCH" : "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(product ? values : { ...values, image: null }),
+		});
+		if (!response.ok) throw new Error(await responseError(response, "Product could not be saved."));
+		const saved = await response.json() as AdminMenuProduct;
+		setProducts((current) => product
+			? current.map((candidate) => candidate.id === saved.id ? saved : candidate)
+			: [...current, saved]);
+		setEditing(undefined);
+		if (!product) chooseView("current");
+	}
+
+	async function archive(product: AdminMenuProduct) {
+		if (!window.confirm(`Archive ${product.name}?\n\nIt will leave the current menu but remain in Past Flavors.`)) return;
+		setProductErrors((current) => ({ ...current, [product.id]: "" }));
+		try {
+			const response = await fetch(`/api/admin/products/${encodeURIComponent(product.id)}/archive`, { method: "POST" });
+			if (!response.ok) {
+				const message = await responseError(response, "This product could not be archived. Please try again.");
+				setProductErrors((current) => ({ ...current, [product.id]: message }));
+				return;
+			}
+			updateProduct(await response.json());
+		} catch {
+			setProductErrors((current) => ({ ...current, [product.id]: "This product could not be archived. Check your connection and try again." }));
+		}
+	}
+
+	async function restore(product: AdminMenuProduct) {
+		setProductErrors((current) => ({ ...current, [product.id]: "" }));
+		const productPath = `/api/admin/products/${encodeURIComponent(product.id)}`;
+		try {
+			const unarchiveResponse = await fetch(`${productPath}/unarchive`, { method: "POST" });
+			if (!unarchiveResponse.ok) {
+				const message = await responseError(unarchiveResponse, "This flavor could not be restored. Please try again.");
+				setProductErrors((current) => ({ ...current, [product.id]: message }));
+				return;
+			}
+			const restored = await unarchiveResponse.json() as AdminMenuProduct;
+			const resetResponse = await fetch("/api/admin/inventory", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ product_id: product.id, quantity_on_hand: 0 }),
+			});
+			if (!resetResponse.ok) {
+				await fetch(`${productPath}/archive`, { method: "POST" }).catch(() => undefined);
+				await refreshProduct(product.id);
+				const message = await responseError(resetResponse, "This flavor could not be restored safely. Please try again.");
+				setProductErrors((current) => ({ ...current, [product.id]: message }));
+				return;
+			}
+			updateProduct({ ...restored, quantityOnHand: 0 });
+			chooseView("current");
+		} catch {
+			await refreshProduct(product.id);
+			setProductErrors((current) => ({ ...current, [product.id]: "This flavor could not be restored. Check your connection and try again." }));
+		}
+	}
+
+	const views = splitMenuProducts(products);
+	if (loading) return <p className="py-10 text-center text-sage" role="status">Loading menu…</p>;
+	if (loadError) return <div className="py-8"><p className="rounded-lg bg-berry/10 px-4 py-3 text-berry" role="alert">{loadError}</p><button className="btn-primary mt-4" onClick={() => void loadMenu()}>Try Again</button></div>;
+
+	return (
+		<>
+			<div className="flex items-start justify-between gap-3">
+				<div><h1 className="font-display text-2xl font-semibold text-cocoa">Menu</h1><p className="mt-1 text-sm text-sage">Manage what is available today.</p></div>
+				<button type="button" className="btn-primary shrink-0" onClick={() => setEditing(null)} disabled={categories.length === 0}>Add Product</button>
+			</div>
+			<div className="mt-6 grid grid-cols-2 rounded-button border border-crust bg-wheat p-1" role="tablist" aria-label="Menu views">
+				<button type="button" role="tab" aria-selected={view === "current"} className={`min-h-11 rounded-lg px-3 font-semibold ${view === "current" ? "bg-cream text-cocoa shadow-soft" : "text-sage"}`} onClick={() => chooseView("current")}>Current Menu ({views.active.length})</button>
+				<button type="button" role="tab" aria-selected={view === "past"} className={`min-h-11 rounded-lg px-3 font-semibold ${view === "past" ? "bg-cream text-cocoa shadow-soft" : "text-sage"}`} onClick={() => chooseView("past")}>Past Flavors ({views.archived.length})</button>
+			</div>
+			<section className="mt-5 grid gap-4" aria-label={view === "current" ? "Current menu" : "Past Flavors"}>
+				{view === "current" ? views.active.map((product) => <MenuProductCard key={product.id} product={product} pending={pending[product.id]} error={productErrors[product.id]} onAdjust={(delta) => adjust(product.id, delta)} onEdit={() => setEditing(product)} onArchive={() => void archive(product)} />) : views.archived.map((product) => <PastFlavorCard key={product.id} product={product} error={productErrors[product.id]} onEdit={() => setEditing(product)} onRestore={() => void restore(product)} />)}
+				{(view === "current" ? views.active : views.archived).length === 0 && <p className="card-warm p-5 text-sage">{view === "current" ? "No products are on the current menu yet." : "No Past Flavors yet."}</p>}
+			</section>
+			{editing !== undefined && <ProductForm key={editing?.id ?? "new"} product={editing} categories={categories} onCancel={() => setEditing(undefined)} onSave={saveProduct} />}
+		</>
+	);
+}

--- a/components/admin/menu/MenuProductCard.test.ts
+++ b/components/admin/menu/MenuProductCard.test.ts
@@ -1,0 +1,54 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { AdminMenuProduct } from "@/lib/adminMenu";
+import { MenuProductCard, PastFlavorCard } from "./MenuProductCard";
+
+function product(quantityOnHand: number): AdminMenuProduct {
+	return {
+		id: "chocolate-cake",
+		categoryId: "cakes",
+		name: "Chocolate Cake",
+		description: "Rich chocolate cake",
+		priceCents: 350,
+		image: null,
+		maxPerOrder: 6,
+		isArchived: false,
+		sortOrder: 10,
+		quantityOnHand,
+	};
+}
+
+describe("MenuProductCard", () => {
+	it("renders the authoritative quantity with touch adjustment controls", () => {
+		const html = renderToStaticMarkup(createElement(MenuProductCard, {
+			product: product(12), onAdjust: vi.fn(), onEdit: vi.fn(), onArchive: vi.fn(),
+		}));
+
+		expect(html).toContain("12 available");
+		expect(html).toContain("Remove one Chocolate Cake");
+		expect(html).toContain("Add one Chocolate Cake");
+		expect(html).toContain("h-12 w-12");
+	});
+
+	it("keeps a zero-stock active product visible and refillable", () => {
+		const html = renderToStaticMarkup(createElement(MenuProductCard, {
+			product: product(0), onAdjust: vi.fn(), onEdit: vi.fn(), onArchive: vi.fn(),
+		}));
+
+		expect(html).toContain("Chocolate Cake");
+		expect(html).toContain("Sold Out · 0 available");
+		expect(html).toContain("Refill");
+		expect(html).toContain("disabled");
+	});
+
+	it("does not render quantity controls for a Past Flavor", () => {
+		const html = renderToStaticMarkup(createElement(PastFlavorCard, {
+			product: { ...product(8), isArchived: true }, onEdit: vi.fn(), onRestore: vi.fn(),
+		}));
+
+		expect(html).toContain("Restore");
+		expect(html).not.toContain("Add one Chocolate Cake");
+		expect(html).not.toContain("Refill");
+	});
+});

--- a/components/admin/menu/MenuProductCard.tsx
+++ b/components/admin/menu/MenuProductCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { parseRefillAmount, type AdminMenuProduct } from "@/lib/adminMenu";
+
+type MenuProductCardProps = {
+	product: AdminMenuProduct;
+	pending?: number;
+	error?: string;
+	onAdjust: (delta: number) => void;
+	onEdit: () => void;
+	onArchive: () => void;
+};
+
+export function MenuProductCard({ product, pending = 0, error, onAdjust, onEdit, onArchive }: MenuProductCardProps) {
+	const [refilling, setRefilling] = useState(false);
+	const [amount, setAmount] = useState("");
+	const [refillError, setRefillError] = useState<string | null>(null);
+	const soldOut = product.quantityOnHand === 0;
+
+	function submitRefill(event: React.FormEvent) {
+		event.preventDefault();
+		const parsed = parseRefillAmount(amount);
+		if (parsed === null) {
+			setRefillError("Enter a whole number, 0 or more.");
+			return;
+		}
+		setRefillError(null);
+		onAdjust(parsed);
+		setAmount("");
+		setRefilling(false);
+	}
+
+	return (
+		<article className="card-warm p-4 sm:p-5">
+			<div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center">
+				<div className="min-w-0 flex-1">
+					<h2 className="break-words font-display text-lg font-semibold text-cocoa">{product.name}</h2>
+					<p className={`mt-1 text-sm font-semibold ${soldOut ? "text-berry" : "text-success"}`}>{soldOut ? "Sold Out · 0 available" : `${product.quantityOnHand} available`}</p>
+					{pending > 0 && <p className="mt-1 text-xs text-sage" role="status">Updating {pending === 1 ? "change" : `${pending} changes`}…</p>}
+				</div>
+				<div className="flex items-center justify-between gap-2 sm:justify-end">
+					<div className="flex items-center gap-2" aria-label={`Change quantity for ${product.name}`}>
+						<button type="button" onClick={() => onAdjust(-1)} disabled={soldOut} className="flex h-12 w-12 items-center justify-center rounded-button border border-caramel bg-cream text-2xl font-semibold text-caramel disabled:opacity-40" aria-label={`Remove one ${product.name}`}>−</button>
+						<strong className="w-10 text-center text-xl tabular-nums" aria-live="polite">{product.quantityOnHand}</strong>
+						<button type="button" onClick={() => onAdjust(1)} className="flex h-12 w-12 items-center justify-center rounded-button border border-caramel bg-honey text-2xl font-semibold text-white" aria-label={`Add one ${product.name}`}>+</button>
+					</div>
+					<button type="button" className="min-h-12 rounded-button px-3 font-semibold text-caramel underline decoration-caramel/40 underline-offset-4" onClick={onEdit}>Edit</button>
+				</div>
+			</div>
+			{(error || refillError) && <p className="mt-3 rounded-lg bg-berry/10 px-3 py-2 text-sm text-berry" role="alert">{error ?? refillError}</p>}
+			<div className="mt-3 flex items-center gap-4 border-t border-crust pt-3 text-sm">
+				<button type="button" className="min-h-11 font-semibold text-caramel underline underline-offset-4" onClick={() => setRefilling((current) => !current)}>Refill</button>
+				<button type="button" className="min-h-11 text-berry underline underline-offset-4" onClick={onArchive}>Archive</button>
+			</div>
+			{refilling && <form className="mt-2 flex flex-wrap items-end gap-2" onSubmit={submitRefill}><label className="min-w-0 flex-1"><span className="mb-1 block text-sm font-medium">Add</span><input className="input-base" inputMode="numeric" value={amount} onChange={(event) => setAmount(event.target.value)} placeholder="12" aria-label={`Refill amount for ${product.name}`} /></label><button type="submit" className="btn-primary">Confirm</button></form>}
+		</article>
+	);
+}
+
+export function PastFlavorCard({ product, error, onEdit, onRestore }: { product: AdminMenuProduct; error?: string; onEdit: () => void; onRestore: () => void }) {
+	return (
+		<article className="card-warm p-4 sm:p-5">
+			<h2 className="break-words font-display text-lg font-semibold text-cocoa">{product.name}</h2>
+			{product.description && <p className="mt-1 text-sm text-sage">{product.description}</p>}
+			{error && <p className="mt-3 rounded-lg bg-berry/10 px-3 py-2 text-sm text-berry" role="alert">{error}</p>}
+			<div className="mt-4 flex gap-3"><button type="button" className="btn-secondary min-h-11" onClick={onEdit}>Edit</button><button type="button" className="btn-primary" onClick={onRestore}>Restore</button></div>
+		</article>
+	);
+}

--- a/components/admin/menu/ProductForm.tsx
+++ b/components/admin/menu/ProductForm.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminMenuCategory, AdminMenuProduct } from "@/lib/adminMenu";
+
+type ProductFormProps = {
+	product: AdminMenuProduct | null;
+	categories: AdminMenuCategory[];
+	onCancel: () => void;
+	onSave: (values: {
+		name: string;
+		description: string;
+		priceCents: number;
+		categoryId: string;
+		maxPerOrder: number;
+	}) => Promise<void>;
+};
+
+export function ProductForm({ product, categories, onCancel, onSave }: ProductFormProps) {
+	const [name, setName] = useState(product?.name ?? "");
+	const [description, setDescription] = useState(product?.description ?? "");
+	const [price, setPrice] = useState(product ? (product.priceCents / 100).toFixed(2) : "");
+	const [categoryId, setCategoryId] = useState(product?.categoryId ?? categories[0]?.id ?? "");
+	const [maxPerOrder, setMaxPerOrder] = useState(String(product?.maxPerOrder ?? 12));
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	async function submit(event: React.FormEvent) {
+		event.preventDefault();
+		const parsedPrice = /^\d+(\.\d{1,2})?$/.test(price) ? Math.round(Number(price) * 100) : -1;
+		const parsedMaximum = /^\d+$/.test(maxPerOrder) ? Number(maxPerOrder) : 0;
+		if (!name.trim() || parsedPrice < 0 || !Number.isSafeInteger(parsedMaximum) || parsedMaximum < 1 || !categoryId) {
+			setError("Please enter a name, price, category, and whole-number order limit.");
+			return;
+		}
+		setSaving(true);
+		setError(null);
+		try {
+			await onSave({
+				name: name.trim(),
+				description: description.trim(),
+				priceCents: parsedPrice,
+				categoryId,
+				maxPerOrder: parsedMaximum,
+			});
+		} catch (saveError) {
+			setError(saveError instanceof Error ? saveError.message : "Product could not be saved.");
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="fixed inset-0 z-40 flex items-end bg-cocoa/40 p-0 sm:items-center sm:justify-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="product-form-title">
+			<section className="max-h-[92vh] w-full overflow-y-auto rounded-t-card border border-crust bg-cream p-5 shadow-card sm:max-w-lg sm:rounded-card sm:p-6">
+				<h2 id="product-form-title" className="font-display text-xl font-semibold text-cocoa">
+					{product ? `Edit ${product.name}` : "Add Product"}
+				</h2>
+				{error && <p className="mt-3 rounded-lg bg-berry/10 px-3 py-2 text-sm text-berry" role="alert">{error}</p>}
+				<form onSubmit={submit} className="mt-4 grid gap-4">
+					<label><span className="mb-1 block text-sm font-medium">Name</span><input className="input-base" value={name} onChange={(event) => setName(event.target.value)} required /></label>
+					<label><span className="mb-1 block text-sm font-medium">Description</span><textarea className="input-base min-h-24" value={description} onChange={(event) => setDescription(event.target.value)} /></label>
+					<div className="grid grid-cols-2 gap-3">
+						<label><span className="mb-1 block text-sm font-medium">Price</span><input className="input-base" inputMode="decimal" placeholder="3.50" value={price} onChange={(event) => setPrice(event.target.value)} required /></label>
+						<label><span className="mb-1 block text-sm font-medium">Max per order</span><input className="input-base" inputMode="numeric" value={maxPerOrder} onChange={(event) => setMaxPerOrder(event.target.value)} required /></label>
+					</div>
+					<label><span className="mb-1 block text-sm font-medium">Category</span><select className="input-base" value={categoryId} onChange={(event) => setCategoryId(event.target.value)} required>{categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}</select></label>
+					<div className="mt-2 grid grid-cols-2 gap-3">
+						<button type="button" className="btn-secondary min-h-11" onClick={onCancel} disabled={saving}>Cancel</button>
+						<button type="submit" className="btn-primary" disabled={saving}>{saving ? "Saving…" : "Save Product"}</button>
+					</div>
+				</form>
+			</section>
+		</div>
+	);
+}

--- a/lib/adminMenu.test.ts
+++ b/lib/adminMenu.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ProductActionQueue,
+	parseRefillAmount,
+	splitMenuProducts,
+	type AdminMenuProduct,
+} from "./adminMenu";
+
+function product(overrides: Partial<AdminMenuProduct>): AdminMenuProduct {
+	return {
+		id: "product",
+		categoryId: "cakes",
+		name: "Cake",
+		description: "",
+		priceCents: 300,
+		image: null,
+		maxPerOrder: 6,
+		isArchived: false,
+		sortOrder: 10,
+		quantityOnHand: 4,
+		...overrides,
+	};
+}
+
+describe("admin menu product views", () => {
+	it("keeps active sold-out products visible after stocked products", () => {
+		const views = splitMenuProducts([
+			product({ id: "sold-out", name: "Sold Out", quantityOnHand: 0 }),
+			product({ id: "stocked", name: "Stocked", quantityOnHand: 3 }),
+		]);
+
+		expect(views.active.map((item) => item.id)).toEqual(["stocked", "sold-out"]);
+		expect(views.active[1].quantityOnHand).toBe(0);
+	});
+
+	it("separates archived products into Past Flavors", () => {
+		const views = splitMenuProducts([
+			product({ id: "active" }),
+			product({ id: "past", isArchived: true, quantityOnHand: 8 }),
+		]);
+
+		expect(views.active.map((item) => item.id)).toEqual(["active"]);
+		expect(views.archived.map((item) => item.id)).toEqual(["past"]);
+	});
+});
+
+describe("ProductActionQueue", () => {
+	it("serializes rapid actions for one product without losing any", async () => {
+		let releaseFirst: (() => void) | undefined;
+		let markFirstStarted: (() => void) | undefined;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const firstStarted = new Promise<void>((resolve) => {
+			markFirstStarted = resolve;
+		});
+		const calls: string[] = [];
+		const queue = new ProductActionQueue();
+
+		const first = queue.enqueue("cake", async () => {
+			calls.push("first:start");
+			markFirstStarted?.();
+			await firstGate;
+			calls.push("first:end");
+		});
+		const second = queue.enqueue("cake", async () => {
+			calls.push("second");
+		});
+
+		await firstStarted;
+		expect(calls).toEqual(["first:start"]);
+		releaseFirst?.();
+		await Promise.all([first, second]);
+		expect(calls).toEqual(["first:start", "first:end", "second"]);
+	});
+
+	it("does not globally block actions for different products", async () => {
+		const queue = new ProductActionQueue();
+		const cakeAction = vi.fn(async () => undefined);
+		const cookieAction = vi.fn(async () => undefined);
+
+		await Promise.all([
+			queue.enqueue("cake", cakeAction),
+			queue.enqueue("cookie", cookieAction),
+		]);
+
+		expect(cakeAction).toHaveBeenCalledOnce();
+		expect(cookieAction).toHaveBeenCalledOnce();
+	});
+});
+
+describe("parseRefillAmount", () => {
+	it.each(["0", "12", " 4 "])("accepts non-negative whole amount %s", (value) => {
+		expect(parseRefillAmount(value)).toBe(Number(value));
+	});
+
+	it.each(["", "-1", "1.5", "abc"])("rejects invalid amount %s", (value) => {
+		expect(parseRefillAmount(value)).toBeNull();
+	});
+});

--- a/lib/adminMenu.ts
+++ b/lib/adminMenu.ts
@@ -1,0 +1,48 @@
+export type AdminMenuProduct = {
+	id: string;
+	categoryId: string;
+	name: string;
+	description: string;
+	priceCents: number;
+	image: string | null;
+	maxPerOrder: number;
+	isArchived: boolean;
+	sortOrder: number;
+	quantityOnHand: number;
+};
+
+export type AdminMenuCategory = {
+	id: string;
+	name: string;
+	sortOrder: number;
+};
+
+export function splitMenuProducts(products: AdminMenuProduct[]) {
+	const active = products
+		.filter((product) => !product.isArchived)
+		.sort((left, right) => Number(left.quantityOnHand === 0) - Number(right.quantityOnHand === 0));
+	const archived = products.filter((product) => product.isArchived);
+	return { active, archived };
+}
+
+export function parseRefillAmount(value: string): number | null {
+	if (!/^\s*\d+\s*$/.test(value)) return null;
+	const amount = Number(value);
+	return Number.isSafeInteger(amount) && amount <= 2_147_483_647 ? amount : null;
+}
+
+/** Runs actions in order for each product while allowing other products to update independently. */
+export class ProductActionQueue {
+	private readonly pending = new Map<string, Promise<void>>();
+
+	enqueue(productId: string, action: () => Promise<void>): Promise<void> {
+		const previous = this.pending.get(productId) ?? Promise.resolve();
+		const current = previous.catch(() => undefined).then(action);
+		this.pending.set(productId, current);
+		const cleanup = () => {
+			if (this.pending.get(productId) === current) this.pending.delete(productId);
+		};
+		void current.then(cleanup, cleanup);
+		return current;
+	}
+}

--- a/lib/inventoryUpsert.test.ts
+++ b/lib/inventoryUpsert.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRpc } = vi.hoisted(() => ({ mockRpc: vi.fn() }));
+
+vi.mock("@/lib/supabaseAdmin", () => ({
+	supabaseAdmin: { rpc: mockRpc },
+}));
+
+import { adjustProductInventory } from "./inventoryUpsert";
+
+describe("adjustProductInventory", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("delegates the delta to the atomic database function", async () => {
+		mockRpc.mockResolvedValue({ data: 6, error: null });
+
+		await expect(adjustProductInventory("cake", 1)).resolves.toEqual({
+			ok: true,
+			data: { product_id: "cake", quantity_on_hand: 6 },
+		});
+		expect(mockRpc).toHaveBeenCalledWith("adjust_product_inventory", {
+			p_product_id: "cake",
+			p_delta: 1,
+		});
+	});
+
+	it("maps a below-zero database rejection to a safe baker-facing message", async () => {
+		mockRpc.mockResolvedValue({
+			data: null,
+			error: { message: "INVENTORY_OUT_OF_RANGE: internal detail" },
+		});
+
+		await expect(adjustProductInventory("cake", -1)).resolves.toEqual({
+			ok: false,
+			status: 409,
+			error: "There is not enough available to make that change.",
+		});
+	});
+});

--- a/lib/inventoryUpsert.ts
+++ b/lib/inventoryUpsert.ts
@@ -6,6 +6,10 @@ export type SetProductInventoryInput = {
 	quantity_on_hand: number;
 };
 
+export type InventoryMutationResult =
+	| { ok: true; data: ProductInventory }
+	| { ok: false; status: 400 | 404 | 409; error: string };
+
 export async function setProductInventory(
 	row: SetProductInventoryInput
 ): Promise<{ ok: true; data: ProductInventory } | { ok: false; error: string }> {
@@ -19,4 +23,30 @@ export async function setProductInventory(
 	if (error) return { ok: false, error: error.message };
 	if (!data) return { ok: false, error: `Product ${row.product_id}: inventory state is missing` };
 	return { ok: true, data: data as ProductInventory };
+}
+
+export async function adjustProductInventory(
+	productId: string,
+	delta: number
+): Promise<InventoryMutationResult> {
+	const { data, error } = await supabaseAdmin.rpc("adjust_product_inventory", {
+		p_product_id: productId,
+		p_delta: delta,
+	});
+
+	if (!error && typeof data === "number") {
+		return {
+			ok: true,
+			data: { product_id: productId, quantity_on_hand: data },
+		};
+	}
+	if (error?.message.includes("INVENTORY_NOT_FOUND")) {
+		return { ok: false, status: 404, error: "That product could not be found." };
+	}
+	if (error?.message.includes("INVENTORY_OUT_OF_RANGE")) {
+		return { ok: false, status: 409, error: "There is not enough available to make that change." };
+	}
+
+	console.error("[inventory] atomic adjustment failed", error);
+	return { ok: false, status: 400, error: "Stock could not be updated. Please try again." };
 }

--- a/scripts/test-inventory-db.sh
+++ b/scripts/test-inventory-db.sh
@@ -58,4 +58,23 @@ if [[ "$successes" -ne 1 || "$final_quantity" -ne 0 || "$race_orders" -ne 1 ]]; 
     exit 1
 fi
 
-echo "Inventory database tests passed (last-unit race: 1 success, 1 rejection, final stock 0)."
+# A customer reservation and admin +1 must both apply. Whichever locks first,
+# starting stock 5 becomes 5 after one decrement and one increment.
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
+    -c "UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_vanilla'; DELETE FROM public.orders WHERE id LIKE 'admin_race_%';" >/dev/null
+admin_race_order="SELECT public.create_authoritative_order('admin_race_order','track_admin_race','{\"name\":\"Race Customer\",\"email\":\"race@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cakepop_vanilla\",\"quantity\":1}]'::jsonb);"
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$admin_race_order" >"$results_dir/order" 2>&1 &
+pid_order=$!
+docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "SELECT public.adjust_product_inventory('cakepop_vanilla', 1);" >"$results_dir/admin" 2>&1 &
+pid_admin=$!
+
+wait "$pid_order"
+wait "$pid_admin"
+admin_race_quantity="$(docker exec "$container" psql -At -U postgres -d "$database" -c "SELECT quantity_on_hand FROM public.product_inventory WHERE product_id = 'cakepop_vanilla';")"
+if [[ "$admin_race_quantity" -ne 5 ]]; then
+    cat "$results_dir/order" "$results_dir/admin"
+    echo "admin/order race assertion failed: stock=$admin_race_quantity" >&2
+    exit 1
+fi
+
+echo "Inventory database tests passed (order races and admin delta preserved)."

--- a/supabase/migrations/20260910010000_atomic_admin_inventory_adjustment.sql
+++ b/supabase/migrations/20260910010000_atomic_admin_inventory_adjustment.sql
@@ -1,0 +1,39 @@
+-- Add or subtract from current stock in one database statement so an admin change
+-- cannot overwrite a simultaneous customer reservation.
+CREATE FUNCTION public.adjust_product_inventory(
+    p_product_id TEXT,
+    p_delta INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    resulting_quantity INTEGER;
+BEGIN
+    UPDATE public.product_inventory
+    SET quantity_on_hand = (quantity_on_hand::BIGINT + p_delta)::INTEGER
+    WHERE product_id = p_product_id
+      AND quantity_on_hand::BIGINT + p_delta BETWEEN 0 AND 2147483647
+    RETURNING quantity_on_hand INTO resulting_quantity;
+
+    IF FOUND THEN
+        RETURN resulting_quantity;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.product_inventory WHERE product_id = p_product_id
+    ) THEN
+        RAISE EXCEPTION 'INVENTORY_NOT_FOUND';
+    END IF;
+    RAISE EXCEPTION 'INVENTORY_OUT_OF_RANGE';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.adjust_product_inventory(TEXT, INTEGER)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.adjust_product_inventory(TEXT, INTEGER)
+TO service_role;
+
+COMMENT ON FUNCTION public.adjust_product_inventory(TEXT, INTEGER)
+IS 'Atomically changes current inventory by a delta and returns authoritative resulting stock.';

--- a/supabase/tests/current_product_inventory.sql
+++ b/supabase/tests/current_product_inventory.sql
@@ -183,3 +183,32 @@ SELECT pg_temp.assert_true(
 
 UPDATE public.product_inventory SET quantity_on_hand = 1 WHERE product_id = 'cookie_chocolatechip';
 DELETE FROM public.orders WHERE id LIKE 'race_%';
+
+UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_chocolate';
+SELECT pg_temp.assert_true(
+    public.adjust_product_inventory('cakepop_chocolate', 1) = 6
+    AND public.adjust_product_inventory('cakepop_chocolate', -1) = 5,
+    'admin adjustments add and subtract exact deltas'
+);
+SELECT pg_temp.assert_true(
+    public.adjust_product_inventory('cakepop_chocolate', 12) = 17,
+    'refill adds to current stock instead of replacing it'
+);
+DO $$ BEGIN
+    BEGIN
+        PERFORM public.adjust_product_inventory('cakepop_chocolate', -18);
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN
+        IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'INVENTORY_OUT_OF_RANGE%' THEN RAISE; END IF;
+    END;
+END $$;
+SELECT pg_temp.assert_true(
+    (SELECT quantity_on_hand = 17 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate'),
+    'failed decrement cannot make inventory negative'
+);
+SELECT pg_temp.assert_true(
+    NOT has_function_privilege('anon', 'public.adjust_product_inventory(text,integer)', 'EXECUTE')
+    AND NOT has_function_privilege('authenticated', 'public.adjust_product_inventory(text,integer)', 'EXECUTE')
+    AND has_function_privilege('service_role', 'public.adjust_product_inventory(text,integer)', 'EXECUTE'),
+    'atomic admin adjustment is available only to the server role'
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	plugins: [react()],
 	resolve: {
 		alias: {
 			"@": fileURLToPath(new URL(".", import.meta.url)),


### PR DESCRIPTION
## Summary

- add a mobile-first authenticated Menu page with Current Menu and Past Flavors views
- add touch-friendly serialized quantity adjustments, Refill, product create/edit, archive confirmation, and restore-to-zero
- replace technical inventory navigation with owner-facing Orders, Menu, Demand, Past Flavors, and Logout
- add an authenticated database-atomic inventory delta operation that preserves concurrent customer order changes
- keep `/admin` landing on Orders and retain legacy bulk inventory tooling outside normal navigation

## Inventory correctness

`adjust_product_inventory(product_id, delta)` updates the current database quantity in one guarded statement, prevents negative or overflowing stock, and returns the authoritative result. Execution is restricted to the server service role. Client requests are serialized per product so rapid taps cannot display out-of-order results.

The database race test starts at 5 and runs a customer order decrement concurrently with an admin `+1`; both operations are preserved and final stock is 5.

## Verification

- `npm test` — 26 files, 122 tests passed
- `npm run lint` — no warnings or errors
- `npx tsc --noEmit --incremental false` — passed
- `npm run build` — passed, 28/28 static pages
- `npm run test:db` — passed, including order/admin concurrency
- Chromium checks at 320px and 390px — no horizontal overflow; 48x48 quantity controls; collapsed admin navigation

## Scope

Image uploading (#10), demand reactions/counts (#11), customer-menu redesign, and removal of legacy developer bulk APIs remain intentionally untouched.

Closes #9