### PR TITLE
Issue #12: add isolated order notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ See [DEV_TODO.md](DEV_TODO.md) for a development checklist (Supabase project, mi
 | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Yes | Supabase publishable key used by cookie-backed Auth clients |
 | `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase service role key (server-only) |
 | `NEXT_PUBLIC_VENMO_HANDLE` | No | Venmo handle for checkout (default: @LittleTownBakes) |
+| `NOTIFICATIONS_ENABLED` | No | Set to `true` to enable configured server-side notification channels (default: disabled) |
+| `RESEND_API_KEY` | For email | Resend API key (server-only) |
+| `NOTIFICATION_EMAIL_FROM` | For email | Sender on a Resend-verified domain, e.g. `Little Town Bakes <orders@updates.example.com>` |
+| `BAKER_NOTIFICATION_EMAIL` | For email | Baker inbox that receives operational order notifications (server-only) |
+| `ADMIN_ORDERS_URL` | No | Absolute admin orders URL included in notifications |
+
+## Notifications
+
+Order routes persist changes before awaiting notification delivery. `NotificationService` fans each event out to the configured channels with independent settled results, so one provider failure cannot stop another channel or change a successful order response. Environment-based delivery is always disabled when `NODE_ENV=test`; tests use injected providers instead.
+
+Email is delivered through Resend's HTTPS API. To enable it in production, verify the sender domain in Resend and set all four email-related variables shown above. A partial email configuration is logged and skipped. Leaving notification configuration unset disables delivery cleanly.
+
+Push and SMS have injectable channel/provider interfaces but no production providers yet. Adding either provider does not require changes to the order routes or notification orchestrator.
+
+Every event has a stable key such as `new-order:<order-id>` or `status-change:<order-id>:<fulfillment-status>:<payment-status>`. The email channel appends `:email` and sends it as Resend's idempotency key. Resend deduplicates identical requests for that key during its provider retention window; there is no application-side retry worker or permanent notification ledger.
 
 ## Database
 

--- a/app/api/orders/[id]/status/route.test.ts
+++ b/app/api/orders/[id]/status/route.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
-const mocks = vi.hoisted(() => ({ from: vi.fn(), rpc: vi.fn(), update: vi.fn(), eqSelect: vi.fn(), eqUpdate: vi.fn(), eqStatus: vi.fn(), maybeSingle: vi.fn(), auth: vi.fn() }));
+const mocks = vi.hoisted(() => ({ from: vi.fn(), rpc: vi.fn(), update: vi.fn(), eqSelect: vi.fn(), eqUpdate: vi.fn(), eqStatus: vi.fn(), maybeSingle: vi.fn(), auth: vi.fn(), notify: vi.fn() }));
 vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mocks.auth }));
 vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ from: mocks.from, rpc: mocks.rpc }) }));
-vi.mock("@/lib/notify", () => ({ notifyStatusChange: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/notify", () => ({ notifyStatusChange: mocks.notify }));
 import { POST } from "./route";
 
 function request(body: unknown) { return new NextRequest("http://localhost/api/orders/ord/status", { method: "POST", body: JSON.stringify(body) }); }
 describe("POST order status", () => {
 	beforeEach(() => {
-		vi.clearAllMocks(); mocks.auth.mockResolvedValue({ authorized: true });
+		vi.clearAllMocks(); mocks.auth.mockResolvedValue({ authorized: true }); mocks.notify.mockResolvedValue(undefined);
 		mocks.eqSelect.mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { status: "RECEIVED", payload: {
 			id: "ord", createdAt: "2026-09-09", fulfillmentStatus: "RECEIVED", payment: { method: "cash", status: "PENDING" }, customer: { name: "A", email: "a@b.com" }, items: [], totals: { subtotalCents: 0, totalCents: 0 },
 		} }, error: null }) });
@@ -23,6 +23,13 @@ describe("POST order status", () => {
 		const response = await POST(request({ fulfillmentStatus: "IN_PROGRESS" }), { params: Promise.resolve({ id: "ord" }) });
 		expect(response.status).toBe(200);
 		expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({ status: "IN_PROGRESS", payload: expect.objectContaining({ payment: { method: "cash", status: "PENDING" } }) }));
+		expect(mocks.notify).toHaveBeenCalledWith(expect.objectContaining({ id: "ord", fulfillmentStatus: "IN_PROGRESS" }));
+	});
+	it("keeps a persisted status change successful when notification unexpectedly rejects", async () => {
+		mocks.notify.mockRejectedValue(new Error("provider failure"));
+		const response = await POST(request({ fulfillmentStatus: "IN_PROGRESS" }), { params: Promise.resolve({ id: "ord" }) });
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ ok: true });
 	});
 	it("marks payment paid without changing fulfillment or inventory", async () => {
 		const response = await POST(request({ paymentStatus: "PAID" }), { params: Promise.resolve({ id: "ord" }) });

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -53,7 +53,13 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
 	if (fulfillmentStatus === "CANCELED") {
 		const { data: cancellation, error: cancelError } = await supabase.rpc("cancel_order_and_restore_inventory", { p_order_id: id });
 		if (cancelError) { console.error("[orders] cancellation failed", cancelError); return NextResponse.json({ error: "Could not cancel order" }, { status: 400 }); }
-		if (cancellation?.restored !== false) notifyStatusChange(updated).catch(console.warn);
+		if (cancellation?.restored !== false) {
+			try {
+				await notifyStatusChange(updated);
+			} catch {
+				console.error("[orders] status notification orchestration failed", { orderId: updated.id });
+			}
+		}
 		return NextResponse.json({ ok: true });
 	}
 
@@ -61,6 +67,10 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
 		.eq("id", id).eq("status", previous.fulfillmentStatus).select("id").maybeSingle();
 	if (updateError) return NextResponse.json({ error: "Could not update fulfillment status" }, { status: 400 });
 	if (!changed) return NextResponse.json({ error: "Order changed; refresh and try again" }, { status: 409 });
-	notifyStatusChange(updated).catch(console.warn);
+	try {
+		await notifyStatusChange(updated);
+	} catch {
+		console.error("[orders] status notification orchestration failed", { orderId: updated.id });
+	}
 	return NextResponse.json({ ok: true });
 }

--- a/app/api/orders/route.test.ts
+++ b/app/api/orders/route.test.ts
@@ -47,6 +47,39 @@ describe("POST /api/orders", () => {
 		expect(mockNotify).toHaveBeenCalledWith(authoritativeOrder);
 	});
 
+	it("starts notification only after persistence and awaits it before responding", async () => {
+		let finishNotification: (() => void) | undefined;
+		mockNotify.mockImplementation(() => new Promise<void>((resolve) => { finishNotification = resolve; }));
+
+		const responsePromise = POST(request(trustedRequest));
+		await vi.waitFor(() => expect(mockNotify).toHaveBeenCalledWith(authoritativeOrder));
+		expect(mockRpc.mock.invocationCallOrder[0]).toBeLessThan(mockNotify.mock.invocationCallOrder[0]);
+		let responded = false;
+		void responsePromise.then(() => { responded = true; });
+		await Promise.resolve();
+		expect(responded).toBe(false);
+
+		finishNotification?.();
+		expect((await responsePromise).status).toBe(201);
+	});
+
+	it("returns the persisted order when notification orchestration unexpectedly rejects", async () => {
+		mockNotify.mockRejectedValue(new Error("provider configuration failed"));
+
+		const response = await POST(request(trustedRequest));
+
+		expect(response.status).toBe(201);
+		expect(await response.json()).toMatchObject({ order: authoritativeOrder });
+	});
+
+	it("does not notify when persistence fails", async () => {
+		mockRpc.mockResolvedValue({ data: null, error: { message: "OUT_OF_STOCK" } });
+
+		await POST(request(trustedRequest));
+
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
 	it.each([["INVALID_PRODUCT", 400], ["PRODUCT_UNAVAILABLE", 409], ["MAX_QUANTITY_EXCEEDED", 400], ["OUT_OF_STOCK", 409]])(
 		"maps %s without exposing database details", async (code, status) => {
 			mockRpc.mockResolvedValue({ data: null, error: { message: `${code}: secret table detail` } });

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -39,7 +39,11 @@ export async function POST(req: NextRequest) {
 		if (error) { console.error("[orders] authoritative order failed", error); return databaseError(error.message); }
 		const order = data?.order as OrderRecord | undefined;
 		if (!order) { console.error("[orders] authoritative order returned no order", data); return databaseError(); }
-		notifyNewOrder(order).catch(console.warn);
+		try {
+			await notifyNewOrder(order);
+		} catch {
+			console.error("[orders] notification orchestration failed", { orderId: order.id });
+		}
 		return NextResponse.json({ trackingToken, order }, { status: 201 });
 	} catch (error) {
 		console.error("[orders] unexpected failure", error);

--- a/lib/notifications/channels.test.ts
+++ b/lib/notifications/channels.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { EmailChannel, PushChannel, SmsChannel } from "./channels";
+import type { OrderNotification } from "./types";
+
+const notification: OrderNotification = {
+	eventKey: "new-order:ord_123",
+	type: "new-order",
+	adminUrl: "https://bakery.example/admin/orders",
+	order: {
+		id: "ord_123", createdAt: "2026-09-10T18:00:00.000Z", fulfillmentStatus: "RECEIVED",
+		customer: { name: "Alice <Baker>", email: "alice@example.com", phone: "555-0100", notes: "Pickup after 4 & ring bell" },
+		payment: { method: "cash", status: "PENDING" },
+		items: [{ productId: "cake", name: "Chocolate & Vanilla", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
+		totals: { subtotalCents: 5000, totalCents: 5000 },
+	},
+};
+
+describe("notification channels", () => {
+	it("renders baker-facing authoritative order details for email", async () => {
+		const send = vi.fn().mockResolvedValue({ id: "email_1" });
+		const email = new EmailChannel({ send }, { from: "Little Town Bakes <orders@bakery.example>", to: "baker@example.com" });
+
+		await email.send(notification);
+
+		expect(send).toHaveBeenCalledWith(expect.objectContaining({
+			from: "Little Town Bakes <orders@bakery.example>",
+			to: "baker@example.com",
+			subject: expect.stringContaining("ord_123"),
+			html: expect.stringContaining("Alice &lt;Baker&gt;"),
+			idempotencyKey: "new-order:ord_123:email",
+		}));
+		const message = send.mock.calls[0][0];
+		expect(message.text).toContain("Alice <Baker>");
+		expect(message.text).toContain("Pickup after 4 & ring bell");
+		expect(message.text).toContain("Chocolate & Vanilla x 2 — $50.00");
+		expect(message.text).toContain("Payment: cash (PENDING)");
+		expect(message.text).toContain("Admin orders: https://bakery.example/admin/orders");
+	});
+
+	it("provides independently injectable push and SMS provider seams", async () => {
+		const pushSend = vi.fn().mockResolvedValue(undefined);
+		const smsSend = vi.fn().mockResolvedValue(undefined);
+		await new PushChannel({ send: pushSend }).send(notification);
+		await new SmsChannel({ send: smsSend }, { to: "+15550100" }).send(notification);
+
+		expect(pushSend).toHaveBeenCalledWith(expect.objectContaining({ eventKey: "new-order:ord_123:push", orderId: "ord_123" }));
+		expect(smsSend).toHaveBeenCalledWith(expect.objectContaining({ eventKey: "new-order:ord_123:sms", to: "+15550100" }));
+	});
+});

--- a/lib/notifications/channels.ts
+++ b/lib/notifications/channels.ts
@@ -1,0 +1,94 @@
+import type {
+	EmailMessage, EmailProvider, NotificationChannel, OrderNotification, PushProvider, SmsProvider,
+} from "./types";
+
+function currency(cents: number): string {
+	return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+}
+
+function escapeHtml(value: string): string {
+	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+
+function eventTitle(notification: OrderNotification): string {
+	return notification.type === "new-order"
+		? `New order ${notification.order.id}`
+		: `Order ${notification.order.id} is ${notification.order.fulfillmentStatus.replaceAll("_", " ").toLowerCase()}`;
+}
+
+function renderEmail(notification: OrderNotification, from: string, to: string): EmailMessage {
+	const { order } = notification;
+	const itemLines = order.items.map((item) => `${item.name} x ${item.quantity} — ${currency(item.lineTotalCents)}`);
+	const detailLines = [
+		`Order: ${order.id}`,
+		`Created: ${order.createdAt}`,
+		`Customer: ${order.customer.name}`,
+		`Email: ${order.customer.email}`,
+		order.customer.phone ? `Phone: ${order.customer.phone}` : undefined,
+		order.customer.notes ? `Customer notes / pickup information: ${order.customer.notes}` : undefined,
+		"",
+		"Items:",
+		...itemLines,
+		"",
+		`Subtotal: ${currency(order.totals.subtotalCents)}`,
+		`Total: ${currency(order.totals.totalCents)}`,
+		`Payment: ${order.payment.method} (${order.payment.status})`,
+		`Fulfillment: ${order.fulfillmentStatus}`,
+		order.payment.venmoUser ? `Venmo user: ${order.payment.venmoUser}` : undefined,
+		order.payment.note ? `Payment note: ${order.payment.note}` : undefined,
+		order.customer.notes ? undefined : "Pickup information: not specified on this order",
+		notification.adminUrl ? `Admin orders: ${notification.adminUrl}` : undefined,
+	].filter((line): line is string => line !== undefined);
+	const text = detailLines.join("\n");
+	const html = `<h1>${escapeHtml(eventTitle(notification))}</h1><pre style="font-family: sans-serif; white-space: pre-wrap">${escapeHtml(text)}</pre>`;
+
+	return {
+		from,
+		to,
+		subject: eventTitle(notification),
+		text,
+		html,
+		idempotencyKey: `${notification.eventKey}:email`,
+	};
+}
+
+export class EmailChannel implements NotificationChannel {
+	readonly name = "email" as const;
+
+	constructor(private readonly provider: EmailProvider, private readonly config: { from: string; to: string }) {}
+
+	async send(notification: OrderNotification): Promise<void> {
+		await this.provider.send(renderEmail(notification, this.config.from, this.config.to));
+	}
+}
+
+export class PushChannel implements NotificationChannel {
+	readonly name = "push" as const;
+
+	constructor(private readonly provider: PushProvider) {}
+
+	async send(notification: OrderNotification): Promise<void> {
+		await this.provider.send({
+			title: eventTitle(notification),
+			body: `${notification.order.customer.name} · ${currency(notification.order.totals.totalCents)}`,
+			eventKey: `${notification.eventKey}:push`,
+			orderId: notification.order.id,
+			adminUrl: notification.adminUrl,
+		});
+	}
+}
+
+export class SmsChannel implements NotificationChannel {
+	readonly name = "sms" as const;
+
+	constructor(private readonly provider: SmsProvider, private readonly config: { to: string }) {}
+
+	async send(notification: OrderNotification): Promise<void> {
+		const adminLink = notification.adminUrl ? ` ${notification.adminUrl}` : "";
+		await this.provider.send({
+			to: this.config.to,
+			body: `${eventTitle(notification)}: ${notification.order.customer.name}, ${currency(notification.order.totals.totalCents)}.${adminLink}`,
+			eventKey: `${notification.eventKey}:sms`,
+		});
+	}
+}

--- a/lib/notifications/resend.test.ts
+++ b/lib/notifications/resend.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { ResendEmailProvider } from "./resend";
+
+describe("ResendEmailProvider", () => {
+	it("keeps credentials in the authorization header and uses provider idempotency", async () => {
+		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ id: "email_1" }), { status: 200 }));
+		const provider = new ResendEmailProvider("server-secret", fetch);
+
+		await provider.send({
+			from: "orders@bakery.example", to: "baker@example.com", subject: "New order", text: "Order", html: "<p>Order</p>", idempotencyKey: "new-order:ord_1:email",
+		});
+
+		const [, init] = fetch.mock.calls[0];
+		expect(init.headers).toMatchObject({ Authorization: "Bearer server-secret", "Idempotency-Key": "new-order:ord_1:email" });
+		expect(init.body).not.toContain("server-secret");
+	});
+
+	it("rejects provider errors without exposing credentials", async () => {
+		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ message: "invalid sender" }), { status: 422 }));
+		const provider = new ResendEmailProvider("server-secret", fetch);
+
+		await expect(provider.send({
+			from: "bad", to: "baker@example.com", subject: "New order", text: "Order", html: "<p>Order</p>", idempotencyKey: "new-order:ord_1:email",
+		})).rejects.toThrow("Resend email failed (422): invalid sender");
+	});
+});

--- a/lib/notifications/resend.ts
+++ b/lib/notifications/resend.ts
@@ -1,0 +1,30 @@
+import type { EmailMessage, EmailProvider } from "./types";
+
+type Fetch = typeof globalThis.fetch;
+
+export class ResendEmailProvider implements EmailProvider {
+	constructor(private readonly apiKey: string, private readonly fetch: Fetch = globalThis.fetch) {}
+
+	async send(message: EmailMessage): Promise<{ id?: string }> {
+		const response = await this.fetch("https://api.resend.com/emails", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${this.apiKey}`,
+				"Content-Type": "application/json",
+				"Idempotency-Key": message.idempotencyKey,
+			},
+			body: JSON.stringify({
+				from: message.from,
+				to: [message.to],
+				subject: message.subject,
+				text: message.text,
+				html: message.html,
+			}),
+		});
+		const body = await response.json().catch(() => ({})) as { id?: string; message?: string };
+		if (!response.ok) {
+			throw new Error(`Resend email failed (${response.status}): ${body.message ?? "unknown provider error"}`);
+		}
+		return { id: body.id };
+	}
+}

--- a/lib/notifications/service.test.ts
+++ b/lib/notifications/service.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NotificationChannel } from "./types";
+import { NotificationService } from "./service";
+
+const order = {
+	id: "ord_authoritative",
+	createdAt: "2026-09-10T18:00:00.000Z",
+	fulfillmentStatus: "RECEIVED" as const,
+	payment: { method: "venmo" as const, status: "PAID" as const, venmoUser: "@alice" },
+	customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Friday pickup" },
+	items: [{ productId: "cake", name: "Chocolate Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
+	totals: { subtotalCents: 5000, totalCents: 5000 },
+};
+
+function channel(name: NotificationChannel["name"], send: NotificationChannel["send"]): NotificationChannel {
+	return { name, send };
+}
+
+describe("NotificationService", () => {
+	it("invokes every configured channel with authoritative order content", async () => {
+		const email = vi.fn().mockResolvedValue(undefined);
+		const push = vi.fn().mockResolvedValue(undefined);
+		const sms = vi.fn().mockResolvedValue(undefined);
+		const service = new NotificationService([
+			channel("email", email), channel("push", push), channel("sms", sms),
+		], { adminOrdersUrl: "https://bakery.example/admin/orders" });
+
+		const results = await service.notifyNewOrder(order);
+
+		expect(results).toEqual([
+			{ channel: "email", status: "fulfilled" },
+			{ channel: "push", status: "fulfilled" },
+			{ channel: "sms", status: "fulfilled" },
+		]);
+		for (const send of [email, push, sms]) {
+			expect(send).toHaveBeenCalledWith(expect.objectContaining({
+				eventKey: "new-order:ord_authoritative",
+				type: "new-order",
+				order,
+				adminUrl: "https://bakery.example/admin/orders",
+			}));
+		}
+	});
+
+	it("isolates an SMS failure from successful email and push delivery", async () => {
+		const email = vi.fn().mockResolvedValue(undefined);
+		const push = vi.fn().mockResolvedValue(undefined);
+		const sms = vi.fn().mockRejectedValue(new Error("SMS unavailable"));
+		const logger = { info: vi.fn(), error: vi.fn() };
+		const service = new NotificationService([
+			channel("email", email), channel("sms", sms), channel("push", push),
+		], { logger });
+
+		await expect(service.notifyNewOrder(order)).resolves.toEqual([
+			{ channel: "email", status: "fulfilled" },
+			{ channel: "sms", status: "rejected", error: "SMS unavailable" },
+			{ channel: "push", status: "fulfilled" },
+		]);
+		expect(email).toHaveBeenCalledOnce();
+		expect(push).toHaveBeenCalledOnce();
+		expect(logger.error).toHaveBeenCalledWith("[notifications] channel failed", {
+			channel: "sms", eventKey: "new-order:ord_authoritative", error: "SMS unavailable",
+		});
+	});
+
+	it("isolates an email failure and still attempts push and SMS", async () => {
+		const email = vi.fn().mockRejectedValue(new Error("Email unavailable"));
+		const push = vi.fn().mockResolvedValue(undefined);
+		const sms = vi.fn().mockResolvedValue(undefined);
+		const service = new NotificationService([
+			channel("email", email), channel("push", push), channel("sms", sms),
+		]);
+
+		await expect(service.notifyNewOrder(order)).resolves.toHaveLength(3);
+		expect(push).toHaveBeenCalledOnce();
+		expect(sms).toHaveBeenCalledOnce();
+	});
+
+	it("skips absent channels cleanly and creates a status-specific idempotency key", async () => {
+		const email = vi.fn().mockResolvedValue(undefined);
+		const service = new NotificationService([channel("email", email)]);
+
+		const results = await service.notifyStatusChange({ ...order, fulfillmentStatus: "IN_PROGRESS" });
+
+		expect(results).toEqual([{ channel: "email", status: "fulfilled" }]);
+		expect(email).toHaveBeenCalledWith(expect.objectContaining({
+			eventKey: "status-change:ord_authoritative:IN_PROGRESS:PAID",
+			type: "status-change",
+		}));
+	});
+});

--- a/lib/notifications/service.ts
+++ b/lib/notifications/service.ts
@@ -1,0 +1,58 @@
+import type { OrderRecord } from "../orderTypes";
+import type { ChannelDeliveryResult, NotificationChannel, NotificationLogger, OrderNotification } from "./types";
+
+const defaultLogger: NotificationLogger = console;
+
+function errorMessage(reason: unknown): string {
+	if (reason instanceof Error) return reason.message.slice(0, 500);
+	return "Unknown channel failure";
+}
+
+export class NotificationService {
+	readonly configuredChannels: NotificationChannel["name"][];
+	private readonly channels: NotificationChannel[];
+	private readonly adminOrdersUrl?: string;
+	private readonly logger: NotificationLogger;
+
+	constructor(channels: NotificationChannel[], options: { adminOrdersUrl?: string; logger?: NotificationLogger } = {}) {
+		this.channels = channels;
+		this.configuredChannels = channels.map(({ name }) => name);
+		this.adminOrdersUrl = options.adminOrdersUrl;
+		this.logger = options.logger ?? defaultLogger;
+	}
+
+	notifyNewOrder(order: OrderRecord): Promise<ChannelDeliveryResult[]> {
+		return this.dispatch({
+			eventKey: `new-order:${order.id}`,
+			type: "new-order",
+			order,
+			adminUrl: this.adminOrdersUrl,
+		});
+	}
+
+	notifyStatusChange(order: OrderRecord): Promise<ChannelDeliveryResult[]> {
+		return this.dispatch({
+			eventKey: `status-change:${order.id}:${order.fulfillmentStatus}:${order.payment.status}`,
+			type: "status-change",
+			order,
+			adminUrl: this.adminOrdersUrl,
+		});
+	}
+
+	private async dispatch(notification: OrderNotification): Promise<ChannelDeliveryResult[]> {
+		const attempts = this.channels.map((channel) => Promise.resolve().then(() => channel.send(notification)));
+		const settled = await Promise.allSettled(attempts);
+
+		return settled.map((result, index) => {
+			const channel = this.channels[index].name;
+			if (result.status === "fulfilled") {
+				this.logger.info("[notifications] channel delivered", { channel, eventKey: notification.eventKey });
+				return { channel, status: "fulfilled" };
+			}
+
+			const error = errorMessage(result.reason);
+			this.logger.error("[notifications] channel failed", { channel, eventKey: notification.eventKey, error });
+			return { channel, status: "rejected", error };
+		});
+	}
+}

--- a/lib/notifications/types.ts
+++ b/lib/notifications/types.ts
@@ -1,0 +1,62 @@
+import type { OrderRecord } from "../orderTypes";
+
+export type NotificationChannelName = "email" | "push" | "sms";
+export type NotificationEventType = "new-order" | "status-change";
+
+export type OrderNotification = {
+	eventKey: string;
+	type: NotificationEventType;
+	order: OrderRecord;
+	adminUrl?: string;
+};
+
+export interface NotificationChannel {
+	readonly name: NotificationChannelName;
+	send(notification: OrderNotification): Promise<void>;
+}
+
+export type ChannelDeliveryResult = {
+	channel: NotificationChannelName;
+	status: "fulfilled" | "rejected";
+	error?: string;
+};
+
+export interface NotificationLogger {
+	info(message: string, context: Record<string, unknown>): void;
+	error(message: string, context: Record<string, unknown>): void;
+}
+
+export type EmailMessage = {
+	from: string;
+	to: string;
+	subject: string;
+	text: string;
+	html: string;
+	idempotencyKey: string;
+};
+
+export interface EmailProvider {
+	send(message: EmailMessage): Promise<{ id?: string }>;
+}
+
+export type PushMessage = {
+	title: string;
+	body: string;
+	eventKey: string;
+	orderId: string;
+	adminUrl?: string;
+};
+
+export interface PushProvider {
+	send(message: PushMessage): Promise<void>;
+}
+
+export type SmsMessage = {
+	to: string;
+	body: string;
+	eventKey: string;
+};
+
+export interface SmsProvider {
+	send(message: SmsMessage): Promise<void>;
+}

--- a/lib/notify.test.ts
+++ b/lib/notify.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNotificationServiceFromEnvironment } from "./notify";
+
+describe("notification environment configuration", () => {
+	it("does not configure production delivery in test mode", async () => {
+		const fetch = vi.fn();
+		const service = createNotificationServiceFromEnvironment({
+			NODE_ENV: "test", NOTIFICATIONS_ENABLED: "true", RESEND_API_KEY: "production-key",
+			NOTIFICATION_EMAIL_FROM: "orders@bakery.example", BAKER_NOTIFICATION_EMAIL: "baker@example.com",
+		}, { fetch });
+
+		expect(service.configuredChannels).toEqual([]);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("skips an unconfigured email channel", () => {
+		const service = createNotificationServiceFromEnvironment({ NODE_ENV: "production", NOTIFICATIONS_ENABLED: "true" });
+		expect(service.configuredChannels).toEqual([]);
+	});
+
+	it("reports partial provider configuration without enabling the channel", () => {
+		const logger = { info: vi.fn(), error: vi.fn() };
+		const service = createNotificationServiceFromEnvironment({
+			NODE_ENV: "production", NOTIFICATIONS_ENABLED: "true", RESEND_API_KEY: "secret",
+		}, { logger });
+
+		expect(service.configuredChannels).toEqual([]);
+		expect(logger.error).toHaveBeenCalledWith("[notifications] email configuration incomplete", {
+			missing: ["NOTIFICATION_EMAIL_FROM", "BAKER_NOTIFICATION_EMAIL"],
+		});
+	});
+});

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,10 +1,45 @@
 import type { OrderRecord } from "./orderTypes";
+import { EmailChannel } from "./notifications/channels";
+import { ResendEmailProvider } from "./notifications/resend";
+import { NotificationService } from "./notifications/service";
+import type { NotificationChannel, NotificationLogger } from "./notifications/types";
 
-/** Placeholder until a provider (e.g. Resend, Postmark) is wired; logs only. */
+type NotificationEnvironment = Record<string, string | undefined>;
+type NotificationDependencies = { fetch?: typeof globalThis.fetch; logger?: NotificationLogger };
+
+export function createNotificationServiceFromEnvironment(
+	environment: NotificationEnvironment,
+	dependencies: NotificationDependencies = {},
+): NotificationService {
+	const logger = dependencies.logger ?? console;
+	const channels: NotificationChannel[] = [];
+	if (environment.NODE_ENV === "test" || environment.NOTIFICATIONS_ENABLED !== "true") {
+		return new NotificationService(channels, { logger });
+	}
+
+	const emailVariables = ["RESEND_API_KEY", "NOTIFICATION_EMAIL_FROM", "BAKER_NOTIFICATION_EMAIL"] as const;
+	const configuredEmailVariables = emailVariables.filter((name) => Boolean(environment[name]?.trim()));
+	if (configuredEmailVariables.length > 0 && configuredEmailVariables.length < emailVariables.length) {
+		logger.error("[notifications] email configuration incomplete", {
+			missing: emailVariables.filter((name) => !environment[name]?.trim()),
+		});
+	} else if (configuredEmailVariables.length === emailVariables.length) {
+		channels.push(new EmailChannel(
+			new ResendEmailProvider(environment.RESEND_API_KEY!, dependencies.fetch),
+			{ from: environment.NOTIFICATION_EMAIL_FROM!, to: environment.BAKER_NOTIFICATION_EMAIL! },
+		));
+	}
+
+	return new NotificationService(channels, {
+		adminOrdersUrl: environment.ADMIN_ORDERS_URL?.trim() || undefined,
+		logger,
+	});
+}
+
 export async function notifyNewOrder(order: OrderRecord) {
-	console.log("[notify] new order", order.id);
+	return createNotificationServiceFromEnvironment(process.env).notifyNewOrder(order);
 }
 
 export async function notifyStatusChange(order: OrderRecord) {
-	console.log("[notify] status change", order.id, order.fulfillmentStatus);
+	return createNotificationServiceFromEnvironment(process.env).notifyStatusChange(order);
 }


### PR DESCRIPTION
## Summary
- add a provider-neutral notification service with isolated email, push, and SMS channels
- deliver production email through Resend while leaving push and SMS as injectable provider seams
- await delivery only after order persistence and preserve successful order/status responses on notification failure
- add stable per-event idempotency keys and server-only, opt-in configuration

## Verification
- npm test: 166 passed
- npm run lint: passed
- npm run build: passed
- npm run test:db: passed
- npm run test:smoke: passed

## Notes
- no automated test contacts a real provider
- push and SMS production providers remain follow-up work
- direct npx tsc --noEmit still reports an unrelated pre-existing ProductForm test fixture error; Next production build type validation passes

Closes #12