### PR TITLE
[P1] Add customer pickup slot selection with baker-managed availability

### DIFF
--- a/app/admin/availability/page.tsx
+++ b/app/admin/availability/page.tsx
@@ -1,148 +1,132 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { ProductInventory } from "@/lib/inventory";
-import { stringifyInventoryTemplateCsv } from "@/lib/inventoryBulk";
 import { handleAdminAuthFailure } from "@/lib/adminResponse";
+import { formatPickupWindow, toPacificFormValues } from "@/lib/pickupWindows";
 
-type MenuItem = { id: string; name: string };
+type PickupWindowRow = { id: string; start_at: string; end_at: string; enabled: boolean };
+type WindowForm = { date: string; startTime: string; endTime: string };
+const EMPTY_FORM: WindowForm = { date: "", startTime: "", endTime: "" };
 
 export default function AdminAvailabilityPage() {
-	const [inventory, setInventory] = useState<ProductInventory[]>([]);
-	const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
+	const [windows, setWindows] = useState<PickupWindowRow[]>([]);
+	const [form, setForm] = useState<WindowForm>(EMPTY_FORM);
+	const [editingId, setEditingId] = useState<string | null>(null);
 	const [loading, setLoading] = useState(true);
-	const [form, setForm] = useState({ product_id: "", quantity_on_hand: 0 });
 	const [saving, setSaving] = useState(false);
-	const [message, setMessage] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [message, setMessage] = useState<string | null>(null);
 
-	async function loadInventory() {
-		const response = await fetch("/api/admin/inventory");
+	async function loadWindows() {
+		const response = await fetch("/api/admin/pickup-windows", { cache: "no-store" });
 		if (!response.ok) {
-			setError(handleAdminAuthFailure(response) ?? `Failed to load inventory (${response.status}).`);
+			setError(handleAdminAuthFailure(response) ?? `Failed to load pickup windows (${response.status}).`);
 			return;
 		}
-		setInventory(await response.json());
+		setWindows(await response.json());
 	}
 
-	useEffect(() => {
-		Promise.all([fetch("/api/admin/inventory"), fetch("/api/menu")])
-			.then(async ([inventoryResponse, menuResponse]) => {
-				if (!inventoryResponse.ok) {
-					setError(handleAdminAuthFailure(inventoryResponse) ?? `Failed to load inventory (${inventoryResponse.status}).`);
-					return;
-				}
-				setInventory(await inventoryResponse.json());
-				const menu = await menuResponse.json();
-				setMenuItems([...(menu.items ?? []), ...(menu.archivedItems ?? [])]);
-			})
-			.finally(() => setLoading(false));
-	}, []);
+	useEffect(() => { void loadWindows().finally(() => setLoading(false)); }, []);
 
-	function triggerDownload(blob: Blob, filename: string) {
-		const url = URL.createObjectURL(blob);
-		const anchor = document.createElement("a");
-		anchor.href = url;
-		anchor.download = filename;
-		anchor.click();
-		URL.revokeObjectURL(url);
-	}
-
-	async function downloadExport(format: "csv" | "json") {
-		const response = await fetch(`/api/admin/inventory/export?format=${format}`);
-		if (!response.ok) {
-			setError(handleAdminAuthFailure(response) ?? `Download failed (${response.status}).`);
-			return;
-		}
-		triggerDownload(await response.blob(), `inventory.${format}`);
-	}
-
-	function downloadTemplate() {
-		const csv = stringifyInventoryTemplateCsv(
-			menuItems.map((item) => ({ product_id: item.id, product_name: item.name }))
-		);
-		triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), "inventory-template.csv");
-	}
-
-	async function uploadBulkFile(file: File) {
+	function beginEdit(window: PickupWindowRow) {
+		const start = toPacificFormValues(window.start_at);
+		const end = toPacificFormValues(window.end_at);
+		setEditingId(window.id);
+		setForm({ date: start.date, startTime: start.time, endTime: end.time });
 		setError(null);
-		const isJson = file.name.toLowerCase().endsWith(".json");
-		const response = await fetch("/api/admin/inventory/bulk", {
-			method: "POST",
-			headers: { "Content-Type": isJson ? "application/json" : "text/csv" },
-			body: await file.text(),
-		});
-		const result = await response.json().catch(() => ({}));
-		if (!response.ok) {
-			setError(handleAdminAuthFailure(response) ?? result.error ?? `Upload failed (${response.status}).`);
-			return;
-		}
-		setMessage(`${result.updated ?? 0} updated${result.errors?.length ? `; ${result.errors.length} failed` : ""}.`);
-		await loadInventory();
+		setMessage(null);
 	}
 
-	async function handleSubmit(event: React.FormEvent) {
+	function cancelEdit() {
+		setEditingId(null);
+		setForm(EMPTY_FORM);
+	}
+
+	async function saveWindow(event: React.FormEvent) {
 		event.preventDefault();
 		setSaving(true);
 		setError(null);
-		const response = await fetch("/api/admin/inventory", {
-			method: "POST",
+		setMessage(null);
+		const idBeingEdited = editingId;
+		const response = await fetch(idBeingEdited ? `/api/admin/pickup-windows/${idBeingEdited}` : "/api/admin/pickup-windows", {
+			method: idBeingEdited ? "PATCH" : "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(form),
 		});
 		setSaving(false);
 		if (!response.ok) {
 			const result = await response.json().catch(() => ({}));
-			setError(handleAdminAuthFailure(response) ?? result.error ?? `Could not save inventory (${response.status}).`);
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Could not save pickup window (${response.status}).`);
 			return;
 		}
-		const saved = await response.json();
-		setInventory((current) => current.map((row) => row.product_id === saved.product_id ? saved : row));
-		setMessage("Inventory saved.");
+		cancelEdit();
+		setMessage(idBeingEdited ? "Pickup window updated." : "Pickup window created.");
+		await loadWindows();
 	}
 
-	if (loading) return <main className="mx-auto max-w-5xl px-4 py-6"><p className="text-sage">Loading...</p></main>;
+	async function toggleWindow(window: PickupWindowRow) {
+		setError(null);
+		setMessage(null);
+		const response = await fetch(`/api/admin/pickup-windows/${window.id}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ enabled: !window.enabled }),
+		});
+		if (!response.ok) {
+			const result = await response.json().catch(() => ({}));
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Could not update pickup window (${response.status}).`);
+			return;
+		}
+		setMessage(window.enabled ? "Pickup window disabled." : "Pickup window enabled.");
+		await loadWindows();
+	}
+
+	if (loading) return <main className="mx-auto max-w-4xl px-4 py-6"><p className="text-sage">Loading...</p></main>;
 
 	return (
-		<main className="mx-auto max-w-5xl px-4 py-6">
-			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Inventory</h1>
-			<p className="mb-6 text-sm text-sage">Set the exact quantity currently on hand for each product.</p>
+		<main className="mx-auto max-w-4xl px-4 py-6">
+			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Pickup availability</h1>
+			<p className="mb-6 text-sm text-sage">Create concrete pickup windows. All dates and times are Pacific Time.</p>
 			{error && <p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">{error}</p>}
 			{message && <p className="mb-4 text-sm text-success" role="status">{message}</p>}
 
 			<section className="card-warm mb-8 p-6 sm:p-8">
-				<h2 className="mb-4 font-display text-lg font-semibold text-cocoa">Update on-hand stock</h2>
-				<form onSubmit={handleSubmit} className="grid max-w-md gap-4">
-					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">Product</span>
-						<select value={form.product_id} onChange={(event) => setForm((current) => ({ ...current, product_id: event.target.value }))} required className="input-base">
-							<option value="">Select product</option>
-							{menuItems.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
-						</select>
+				<h2 className="mb-4 font-display text-lg font-semibold text-cocoa">{editingId ? "Edit pickup window" : "Add pickup window"}</h2>
+				<form onSubmit={saveWindow} className="grid gap-4 sm:grid-cols-3">
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">Date</span>
+						<input type="date" required value={form.date} onChange={(event) => setForm((current) => ({ ...current, date: event.target.value }))} className="input-base" />
 					</label>
-					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">On hand</span>
-						<input type="number" min={0} step={1} value={form.quantity_on_hand} onChange={(event) => setForm((current) => ({ ...current, quantity_on_hand: Number(event.target.value) }))} required className="input-base" />
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">Start time</span>
+						<input type="time" step={60} required value={form.startTime} onChange={(event) => setForm((current) => ({ ...current, startTime: event.target.value }))} className="input-base" />
 					</label>
-					<button type="submit" disabled={saving || !form.product_id} className="btn-primary">{saving ? "Saving..." : "Save"}</button>
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">End time</span>
+						<input type="time" step={60} required value={form.endTime} onChange={(event) => setForm((current) => ({ ...current, endTime: event.target.value }))} className="input-base" />
+					</label>
+					<div className="flex flex-wrap gap-2 sm:col-span-3">
+						<button type="submit" disabled={saving} className="btn-primary">{saving ? "Saving..." : editingId ? "Save changes" : "Add window"}</button>
+						{editingId && <button type="button" onClick={cancelEdit} className="btn-secondary">Cancel</button>}
+					</div>
 				</form>
 			</section>
 
-			<section className="card-warm mb-8 p-6 sm:p-8">
-				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Bulk edit</h2>
-				<div className="mb-4 flex flex-wrap gap-2">
-					<button type="button" onClick={() => void downloadExport("csv")} className="btn-secondary">Download CSV</button>
-					<button type="button" onClick={() => void downloadExport("json")} className="btn-secondary">Download JSON</button>
-					<button type="button" onClick={downloadTemplate} className="btn-secondary">Product template</button>
-				</div>
-				<input type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => { const file = event.target.files?.[0]; event.target.value = ""; if (file) void uploadBulkFile(file); }} className="input-base max-w-md" />
-			</section>
-
 			<section>
-				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Current stock</h2>
-				<div className="overflow-x-auto rounded-card border border-crust bg-wheat/50 shadow-soft">
-					<table className="w-full border-collapse text-left text-sm"><thead><tr className="border-b border-crust bg-cream/90"><th className="px-4 py-3">Product</th><th className="px-4 py-3">On hand</th></tr></thead>
-						<tbody>{inventory.map((row) => <tr key={row.product_id} className="border-b border-crust/80 last:border-0"><td className="px-4 py-3">{menuItems.find((item) => item.id === row.product_id)?.name ?? row.product_id}</td><td className="px-4 py-3 tabular-nums">{row.quantity_on_hand}</td></tr>)}</tbody>
-					</table>
-				</div>
+				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Pickup windows</h2>
+				{windows.length === 0 ? <p className="text-sage">No pickup windows configured.</p> : (
+					<div className="space-y-3">
+						{windows.map((window) => (
+							<div key={window.id} className="card-warm flex flex-wrap items-center justify-between gap-3 p-4">
+								<div className="text-cocoa">
+									<span className="font-medium">{formatPickupWindow({ startAt: window.start_at, endAt: window.end_at }, "short")}</span>
+									<span className={`ml-3 text-sm ${window.enabled ? "text-success" : "text-sage"}`}>{window.enabled ? "Enabled" : "Disabled"}</span>
+								</div>
+								<div className="flex gap-2">
+									<button type="button" onClick={() => beginEdit(window)} className="btn-secondary">Edit</button>
+									<button type="button" onClick={() => void toggleWindow(window)} className={window.enabled ? "btn-danger" : "btn-primary"}>{window.enabled ? "Disable" : "Enable"}</button>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
 			</section>
 		</main>
 	);

--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -1,18 +1,147 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import type { ProductInventory } from "@/lib/inventory";
+import { stringifyInventoryTemplateCsv } from "@/lib/inventoryBulk";
+import { handleAdminAuthFailure } from "@/lib/adminResponse";
 
-/**
- * Redirect from legacy /admin/inventory to /admin/availability.
- * Keeps old bookmarks and links working.
- */
-export default function AdminInventoryRedirect() {
+type MenuItem = { id: string; name: string };
+
+export default function AdminInventoryPage() {
+	const [inventory, setInventory] = useState<ProductInventory[]>([]);
+	const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [form, setForm] = useState({ product_id: "", quantity_on_hand: 0 });
+	const [saving, setSaving] = useState(false);
+	const [message, setMessage] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	async function loadInventory() {
+		const response = await fetch("/api/admin/inventory");
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? `Failed to load inventory (${response.status}).`);
+			return;
+		}
+		setInventory(await response.json());
+	}
+
 	useEffect(() => {
-		window.location.replace("/admin/availability");
+		Promise.all([fetch("/api/admin/inventory"), fetch("/api/menu")])
+			.then(async ([inventoryResponse, menuResponse]) => {
+				if (!inventoryResponse.ok) {
+					setError(handleAdminAuthFailure(inventoryResponse) ?? `Failed to load inventory (${inventoryResponse.status}).`);
+					return;
+				}
+				setInventory(await inventoryResponse.json());
+				const menu = await menuResponse.json();
+				setMenuItems([...(menu.items ?? []), ...(menu.archivedItems ?? [])]);
+			})
+			.finally(() => setLoading(false));
 	}, []);
+
+	function triggerDownload(blob: Blob, filename: string) {
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = filename;
+		anchor.click();
+		URL.revokeObjectURL(url);
+	}
+
+	async function downloadExport(format: "csv" | "json") {
+		const response = await fetch(`/api/admin/inventory/export?format=${format}`);
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? `Download failed (${response.status}).`);
+			return;
+		}
+		triggerDownload(await response.blob(), `inventory.${format}`);
+	}
+
+	function downloadTemplate() {
+		const csv = stringifyInventoryTemplateCsv(menuItems.map((item) => ({ product_id: item.id, product_name: item.name })));
+		triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), "inventory-template.csv");
+	}
+
+	async function uploadBulkFile(file: File) {
+		setError(null);
+		const isJson = file.name.toLowerCase().endsWith(".json");
+		const response = await fetch("/api/admin/inventory/bulk", {
+			method: "POST",
+			headers: { "Content-Type": isJson ? "application/json" : "text/csv" },
+			body: await file.text(),
+		});
+		const result = await response.json().catch(() => ({}));
+		if (!response.ok) {
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Upload failed (${response.status}).`);
+			return;
+		}
+		setMessage(`${result.updated ?? 0} updated${result.errors?.length ? `; ${result.errors.length} failed` : ""}.`);
+		await loadInventory();
+	}
+
+	async function handleSubmit(event: React.FormEvent) {
+		event.preventDefault();
+		setSaving(true);
+		setError(null);
+		const response = await fetch("/api/admin/inventory", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(form),
+		});
+		setSaving(false);
+		if (!response.ok) {
+			const result = await response.json().catch(() => ({}));
+			setError(handleAdminAuthFailure(response) ?? result.error ?? `Could not save inventory (${response.status}).`);
+			return;
+		}
+		const saved = await response.json();
+		setInventory((current) => current.map((row) => row.product_id === saved.product_id ? saved : row));
+		setMessage("Inventory saved.");
+	}
+
+	if (loading) return <main className="mx-auto max-w-5xl px-4 py-6"><p className="text-sage">Loading...</p></main>;
+
 	return (
-		<main className="mx-auto max-w-3xl px-4 py-6">
-			<p className="text-sage">Redirecting...</p>
+		<main className="mx-auto max-w-5xl px-4 py-6">
+			<h1 className="mb-2 font-display text-2xl font-semibold text-cocoa">Inventory</h1>
+			<p className="mb-6 text-sm text-sage">Set the exact quantity currently on hand for each product.</p>
+			{error && <p className="mb-4 rounded-lg bg-berry/10 px-4 py-2 text-berry" role="alert">{error}</p>}
+			{message && <p className="mb-4 text-sm text-success" role="status">{message}</p>}
+
+			<section className="card-warm mb-8 p-6 sm:p-8">
+				<h2 className="mb-4 font-display text-lg font-semibold text-cocoa">Update on-hand stock</h2>
+				<form onSubmit={handleSubmit} className="grid max-w-md gap-4">
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">Product</span>
+						<select value={form.product_id} onChange={(event) => setForm((current) => ({ ...current, product_id: event.target.value }))} required className="input-base">
+							<option value="">Select product</option>
+							{menuItems.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+						</select>
+					</label>
+					<label><span className="mb-1.5 block text-sm font-medium text-cocoa">On hand</span>
+						<input type="number" min={0} step={1} value={form.quantity_on_hand} onChange={(event) => setForm((current) => ({ ...current, quantity_on_hand: Number(event.target.value) }))} required className="input-base" />
+					</label>
+					<button type="submit" disabled={saving || !form.product_id} className="btn-primary">{saving ? "Saving..." : "Save"}</button>
+				</form>
+			</section>
+
+			<section className="card-warm mb-8 p-6 sm:p-8">
+				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Bulk edit</h2>
+				<div className="mb-4 flex flex-wrap gap-2">
+					<button type="button" onClick={() => void downloadExport("csv")} className="btn-secondary">Download CSV</button>
+					<button type="button" onClick={() => void downloadExport("json")} className="btn-secondary">Download JSON</button>
+					<button type="button" onClick={downloadTemplate} className="btn-secondary">Product template</button>
+				</div>
+				<input type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => { const file = event.target.files?.[0]; event.target.value = ""; if (file) void uploadBulkFile(file); }} className="input-base max-w-md" />
+			</section>
+
+			<section>
+				<h2 className="mb-3 font-display text-lg font-semibold text-cocoa">Current stock</h2>
+				<div className="overflow-x-auto rounded-card border border-crust bg-wheat/50 shadow-soft">
+					<table className="w-full border-collapse text-left text-sm"><thead><tr className="border-b border-crust bg-cream/90"><th className="px-4 py-3">Product</th><th className="px-4 py-3">On hand</th></tr></thead>
+						<tbody>{inventory.map((row) => <tr key={row.product_id} className="border-b border-crust/80 last:border-0"><td className="px-4 py-3">{menuItems.find((item) => item.id === row.product_id)?.name ?? row.product_id}</td><td className="px-4 py-3 tabular-nums">{row.quantity_on_hand}</td></tr>)}</tbody>
+					</table>
+				</div>
+			</section>
 		</main>
 	);
 }

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { handleAdminAuthFailure } from "@/lib/adminResponse";
 import type { AdminOrderRecord, FulfillmentStatus, PaymentStatus } from "@/lib/orderTypes";
 import { formatCurrency } from "@/lib/menuCatalog";
+import { formatPickupWindow } from "@/lib/pickupWindows";
 import {
 	getAllowedNextStatuses,
 	orderStatusActionLabel,
@@ -116,6 +117,11 @@ function OrderCard({
 					<button type="button" className="btn-primary" onClick={() => onUpdate(o.id, { paymentStatus: "PAID" })}>Mark paid</button>
 				)}
 			</div>
+			{o.pickup && (
+				<p className="mt-3 rounded-lg border border-crust bg-cream/80 px-3 py-2 text-cocoa">
+					<strong>Pickup:</strong> {formatPickupWindow(o.pickup, "short")}
+				</p>
+			)}
 			<ul className="mt-4 space-y-1 text-sm text-cocoa">
 				{o.items.map((item) => (
 					<li key={item.productId} className="flex justify-between gap-4">

--- a/app/api/admin/list/route.test.ts
+++ b/app/api/admin/list/route.test.ts
@@ -45,6 +45,7 @@ describe("GET /api/admin/list", () => {
 				payload: {
 					customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Baker needs this" },
 					payment: { method: "zelle", status: "PENDING" },
+					pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 					items: [{ productId: "cake", name: "Chocolate Cake", unitPriceCents: 2500, quantity: 1, lineTotalCents: 2500 }],
 					totals: { subtotalCents: 2500, totalCents: 2500 },
 				},
@@ -71,6 +72,7 @@ describe("GET /api/admin/list", () => {
 			customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Baker needs this" },
 			fulfillmentStatus: "IN_PROGRESS",
 			payment: { method: "zelle", status: "PENDING" },
+			pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 			totals: { subtotalCents: 2500, totalCents: 2500 },
 		});
 	});

--- a/app/api/admin/list/route.ts
+++ b/app/api/admin/list/route.ts
@@ -40,6 +40,7 @@ export async function GET(req: NextRequest) {
 			fulfillmentStatus: row.status as OrderRecord["fulfillmentStatus"],
 			payment: payload.payment as OrderRecord["payment"],
 			customer: (payload?.customer ?? { name: "", email: "" }) as OrderRecord["customer"],
+			pickup: payload.pickup as OrderRecord["pickup"],
 			items: (payload?.items ?? []) as OrderRecord["items"],
 			totals: payload.totals as OrderRecord["totals"],
 		};

--- a/app/api/admin/pickup-windows/[id]/route.test.ts
+++ b/app/api/admin/pickup-windows/[id]/route.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFrom, mockRequireAdmin, mockRpc } = vi.hoisted(() => ({
+	mockFrom: vi.fn(), mockRequireAdmin: vi.fn(), mockRpc: vi.fn(),
+}));
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ from: mockFrom, rpc: mockRpc }) }));
+
+import { PATCH } from "./route";
+
+const id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+function request(body: unknown) {
+	return new NextRequest(`http://localhost/api/admin/pickup-windows/${id}`, {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("PATCH /api/admin/pickup-windows/[id]", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireAdmin.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+	});
+
+	it("allows an admin to edit and disable a pickup window", async () => {
+		mockRpc.mockResolvedValue({ data: { id: "replacement-id", enabled: false }, error: null });
+
+		const response = await PATCH(request({
+			date: "2099-09-18", startTime: "18:42", endTime: "19:25", enabled: false,
+		}), { params: Promise.resolve({ id }) });
+
+		expect(response.status).toBe(200);
+		expect(mockRpc).toHaveBeenCalledWith("replace_pickup_window", {
+			p_pickup_window_id: id,
+			p_start_at: "2099-09-19T01:42:00.000Z",
+			p_end_at: "2099-09-19T02:25:00.000Z",
+			p_enabled: false,
+		});
+	});
+
+	it("allows an admin to re-enable a future pickup window", async () => {
+		const existingSingle = vi.fn().mockResolvedValue({ data: {
+			start_at: "2099-09-19T01:42:00.000Z",
+			end_at: "2099-09-19T02:25:00.000Z",
+		}, error: null });
+		const existingEq = vi.fn(() => ({ single: existingSingle }));
+		const existingSelect = vi.fn(() => ({ eq: existingEq }));
+		const maybeSingle = vi.fn().mockResolvedValue({ data: { id, enabled: true }, error: null });
+		const updateSelect = vi.fn(() => ({ maybeSingle }));
+		const updateEq = vi.fn(() => ({ select: updateSelect }));
+		const update = vi.fn(() => ({ eq: updateEq }));
+		mockFrom
+			.mockReturnValueOnce({ select: existingSelect })
+			.mockReturnValueOnce({ update });
+
+		const response = await PATCH(request({ enabled: true }), { params: Promise.resolve({ id }) });
+
+		expect(response.status).toBe(200);
+		expect(update).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+	});
+
+	it("rejects an unauthenticated update before database access", async () => {
+		mockRequireAdmin.mockResolvedValue({ authorized: false, response: new Response(null, { status: 401 }) });
+		const response = await PATCH(request({ enabled: false }), { params: Promise.resolve({ id }) });
+		expect(response.status).toBe(401);
+		expect(mockFrom).not.toHaveBeenCalled();
+	});
+});

--- a/app/api/admin/pickup-windows/[id]/route.ts
+++ b/app/api/admin/pickup-windows/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parsePickupWindowInput, validatePickupWindowTimes } from "@/lib/pickupWindows";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SELECT_FIELDS = "id, start_at, end_at, enabled, created_at, updated_at";
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+	const { id } = await context.params;
+	if (!UUID_PATTERN.test(id)) return NextResponse.json({ error: "Invalid pickup window ID." }, { status: 400 });
+
+	let body: unknown;
+	try { body = await request.json(); } catch { return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }); }
+	if (!body || typeof body !== "object" || Array.isArray(body)) {
+		return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+	}
+	const input = body as Record<string, unknown>;
+	const update: { start_at?: string; end_at?: string; enabled?: boolean; updated_at: string } = {
+		updated_at: new Date().toISOString(),
+	};
+	const editsTimes = input.date !== undefined || input.startTime !== undefined || input.endTime !== undefined;
+	if (editsTimes) {
+		const times = parsePickupWindowInput(input);
+		if ("error" in times) return NextResponse.json({ error: times.error }, { status: 400 });
+		update.start_at = times.startAt;
+		update.end_at = times.endAt;
+	}
+	if (input.enabled !== undefined) {
+		if (typeof input.enabled !== "boolean") return NextResponse.json({ error: "Enabled must be true or false." }, { status: 400 });
+		update.enabled = input.enabled;
+	}
+	if (!editsTimes && update.enabled === undefined) {
+		return NextResponse.json({ error: "No pickup window changes supplied." }, { status: 400 });
+	}
+	if (editsTimes) {
+		const { data, error } = await getSupabaseAdmin().rpc("replace_pickup_window", {
+			p_pickup_window_id: id,
+			p_start_at: update.start_at,
+			p_end_at: update.end_at,
+			p_enabled: update.enabled ?? null,
+		});
+		if (error || !data) return NextResponse.json({ error: "Could not update pickup window." }, { status: 400 });
+		return NextResponse.json(data);
+	}
+
+	if (update.enabled === true) {
+		const { data: existing, error: lookupError } = await getSupabaseAdmin()
+			.from("pickup_windows").select("start_at, end_at").eq("id", id).single();
+		if (lookupError || !existing) return new NextResponse("Not found", { status: 404 });
+		const timeError = validatePickupWindowTimes(existing.start_at, existing.end_at);
+		if (timeError) return NextResponse.json({ error: timeError }, { status: 400 });
+	}
+
+	const { data, error } = await getSupabaseAdmin().from("pickup_windows").update(update)
+		.eq("id", id).select(SELECT_FIELDS).maybeSingle();
+	if (error) return NextResponse.json({ error: "Could not update pickup window." }, { status: 400 });
+	if (!data) return new NextResponse("Not found", { status: 404 });
+	return NextResponse.json(data);
+}

--- a/app/api/admin/pickup-windows/route.test.ts
+++ b/app/api/admin/pickup-windows/route.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFrom, mockRequireAdmin } = vi.hoisted(() => ({ mockFrom: vi.fn(), mockRequireAdmin: vi.fn() }));
+vi.mock("@/lib/adminAuth", () => ({ requireAdmin: mockRequireAdmin }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ from: mockFrom }) }));
+
+import { POST } from "./route";
+
+function request(body: unknown) {
+	return new NextRequest("http://localhost/api/admin/pickup-windows", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("POST /api/admin/pickup-windows", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireAdmin.mockResolvedValue({ authorized: true, admin: { id: "admin" } });
+	});
+
+	it("allows an admin to create a minute-precise Pacific pickup window", async () => {
+		const single = vi.fn().mockResolvedValue({ data: { id: "window-1" }, error: null });
+		const select = vi.fn(() => ({ single }));
+		const insert = vi.fn(() => ({ select }));
+		mockFrom.mockReturnValue({ insert });
+
+		const response = await POST(request({ date: "2099-09-18", startTime: "18:42", endTime: "19:25" }));
+
+		expect(response.status).toBe(201);
+		expect(insert).toHaveBeenCalledWith({
+			start_at: "2099-09-19T01:42:00.000Z",
+			end_at: "2099-09-19T02:25:00.000Z",
+			enabled: true,
+		});
+	});
+
+	it("rejects equal or reversed times", async () => {
+		const response = await POST(request({ date: "2099-09-18", startTime: "18:42", endTime: "18:42" }));
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "End time must be after start time." });
+		expect(mockFrom).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unauthenticated mutation before database access", async () => {
+		mockRequireAdmin.mockResolvedValue({ authorized: false, response: new Response(null, { status: 401 }) });
+		const response = await POST(request({ date: "2099-09-18", startTime: "18:42", endTime: "19:25" }));
+		expect(response.status).toBe(401);
+		expect(mockFrom).not.toHaveBeenCalled();
+	});
+});

--- a/app/api/admin/pickup-windows/route.ts
+++ b/app/api/admin/pickup-windows/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/adminAuth";
+import { parsePickupWindowInput } from "@/lib/pickupWindows";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+
+const SELECT_FIELDS = "id, start_at, end_at, enabled, created_at, updated_at";
+
+export async function GET() {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+
+	const { data, error } = await getSupabaseAdmin()
+		.from("pickup_windows")
+		.select(SELECT_FIELDS)
+		.order("start_at", { ascending: true });
+	if (error) return NextResponse.json({ error: "Could not load pickup windows." }, { status: 400 });
+	return NextResponse.json(data ?? []);
+}
+
+export async function POST(request: NextRequest) {
+	const authorization = await requireAdmin();
+	if (!authorization.authorized) return authorization.response;
+
+	let body: unknown;
+	try { body = await request.json(); } catch { return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }); }
+	if (!body || typeof body !== "object" || Array.isArray(body)) {
+		return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+	}
+	const times = parsePickupWindowInput(body as Record<string, unknown>);
+	if ("error" in times) return NextResponse.json({ error: times.error }, { status: 400 });
+
+	const { data, error } = await getSupabaseAdmin().from("pickup_windows").insert({
+		start_at: times.startAt,
+		end_at: times.endAt,
+		enabled: true,
+	}).select(SELECT_FIELDS).single();
+	if (error || !data) return NextResponse.json({ error: "Could not create pickup window." }, { status: 400 });
+	return NextResponse.json(data, { status: 201 });
+}

--- a/app/api/orders/route.test.ts
+++ b/app/api/orders/route.test.ts
@@ -11,6 +11,7 @@ const authoritativeOrder = {
 	id: "ord_server", createdAt: "2026-09-09T20:00:00.000Z", fulfillmentStatus: "RECEIVED",
 	payment: { method: "cash", status: "PENDING" },
 	customer: { name: "Alice Baker", email: "alice@example.com" },
+	pickup: { windowId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 	items: [{ productId: "cake", name: "Real Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
 	totals: { subtotalCents: 5000, totalCents: 5000 },
 };
@@ -21,7 +22,8 @@ function request(body: unknown) {
 
 const trustedRequest = {
 	customer: { name: "Alice Baker", email: "alice@example.com" },
-	payment: { method: "cash" }, items: [{ productId: "cake", quantity: 2 }],
+	payment: { method: "cash" }, pickupWindowId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+	items: [{ productId: "cake", quantity: 2 }],
 };
 
 describe("POST /api/orders", () => {
@@ -41,6 +43,7 @@ describe("POST /api/orders", () => {
 		expect(mockRpc).toHaveBeenCalledWith("create_authoritative_order", expect.any(Object));
 		expect(args.p_customer).toEqual(trustedRequest.customer);
 		expect(args.p_payment).toEqual({ method: "cash" });
+		expect(args.p_pickup_window_id).toBe(trustedRequest.pickupWindowId);
 		expect(args.p_items).toEqual([{ productId: "cake", quantity: 2 }]);
 		expect(JSON.stringify(args)).not.toContain("Fake");
 		expect(body).toMatchObject({ trackingToken: expect.any(String), order: authoritativeOrder });
@@ -77,6 +80,24 @@ describe("POST /api/orders", () => {
 
 		await POST(request(trustedRequest));
 
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
+	it("rejects a missing pickup selection before calling the database", async () => {
+		const response = await POST(request({ ...trustedRequest, pickupWindowId: undefined }));
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({ code: "INVALID_PICKUP_WINDOW" });
+		expect(mockRpc).not.toHaveBeenCalled();
+	});
+
+	it("returns a clean conflict for an unknown, disabled, edited, or cutoff pickup window", async () => {
+		mockRpc.mockResolvedValue({ data: null, error: { message: "PICKUP_WINDOW_UNAVAILABLE: private detail" } });
+		const response = await POST(request(trustedRequest));
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({
+			code: "PICKUP_WINDOW_UNAVAILABLE",
+			error: "That pickup time is no longer available. Please choose another pickup time.",
+		});
 		expect(mockNotify).not.toHaveBeenCalled();
 	});
 

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -13,6 +13,7 @@ const EXPECTED_ERRORS = {
 	OUT_OF_STOCK: { status: 409, error: "One or more products do not have enough stock." },
 	INVALID_QUANTITY: { status: 400, error: "Quantities must be positive whole numbers." },
 	INVALID_PAYMENT_METHOD: { status: 400, error: "Choose a valid payment method." },
+	PICKUP_WINDOW_UNAVAILABLE: { status: 409, error: "That pickup time is no longer available. Please choose another pickup time." },
 } as const;
 
 function databaseError(message?: string) {
@@ -35,6 +36,7 @@ export async function POST(req: NextRequest) {
 		const { data, error } = await getSupabaseAdmin().rpc("create_authoritative_order", {
 			p_order_id: id, p_tracking_token: trackingToken,
 			p_customer: validation.data.customer, p_payment: validation.data.payment, p_items: validation.data.items,
+			p_pickup_window_id: validation.data.pickupWindowId,
 		});
 		if (error) { console.error("[orders] authoritative order failed", error); return databaseError(error.message); }
 		const order = data?.order as OrderRecord | undefined;

--- a/app/api/orders/track/[token]/route.test.ts
+++ b/app/api/orders/track/[token]/route.test.ts
@@ -10,6 +10,7 @@ describe("GET /api/orders/track/[token]", () => {
 		vi.clearAllMocks();
 		mockEq.mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { status: "RECEIVED", payload: {
 			payment: { method: "cash", status: "PENDING" },
+			pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 1, lineTotalCents: 2500 }],
 			totals: { subtotalCents: 2500, totalCents: 2500 }, customer: { name: "Private", email: "private@example.com" },
 		} }, error: null }) });
@@ -19,8 +20,14 @@ describe("GET /api/orders/track/[token]", () => {
 		const response = await GET(new NextRequest(`http://localhost/api/orders/track/${token}`), { params: Promise.resolve({ token }) });
 		const body = await response.json();
 		expect(response.status).toBe(200);
-		expect(body).toMatchObject({ fulfillmentStatus: "RECEIVED", payment: { method: "cash", status: "PENDING" }, totals: { totalCents: 2500 } });
+		expect(body).toMatchObject({
+			fulfillmentStatus: "RECEIVED",
+			payment: { method: "cash", status: "PENDING" },
+			pickup: { startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
+			totals: { totalCents: 2500 },
+		});
 		expect(body).not.toHaveProperty("customer");
+		expect(body.pickup).not.toHaveProperty("windowId");
 	});
 	it("rejects invalid tokens before querying", async () => {
 		const response = await GET(new NextRequest("http://localhost/api/orders/track/bad"), { params: Promise.resolve({ token: "bad" }) });

--- a/app/api/orders/track/[token]/route.ts
+++ b/app/api/orders/track/[token]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
 
 	if (error || !data) return notFound();
 
-	const payload = data.payload as Pick<OrderRecord, "payment" | "items" | "totals">;
+	const payload = data.payload as Pick<OrderRecord, "payment" | "pickup" | "items" | "totals">;
 	const order = toPublicOrderTracking(data.status as FulfillmentStatus, payload);
 	return NextResponse.json(order, { headers: NO_STORE_HEADERS });
 }

--- a/app/api/pickup-windows/route.test.ts
+++ b/app/api/pickup-windows/route.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRpc } = vi.hoisted(() => ({ mockRpc: vi.fn() }));
+vi.mock("@/lib/supabaseAdmin", () => ({ getSupabaseAdmin: () => ({ rpc: mockRpc }) }));
+
+import { GET } from "./route";
+
+describe("GET /api/pickup-windows", () => {
+	beforeEach(() => { vi.clearAllMocks(); });
+
+	it("returns only customer-safe pickup fields from authoritative availability", async () => {
+		mockRpc.mockResolvedValue({ data: [{
+			id: "window-1",
+			start_at: "2026-09-19T01:42:00.000Z",
+			end_at: "2026-09-19T02:25:00.000Z",
+			enabled: true,
+			created_at: "private metadata",
+		}], error: null });
+
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		expect(mockRpc).toHaveBeenCalledWith("list_available_pickup_windows");
+		expect(await response.json()).toEqual([{
+			id: "window-1",
+			startAt: "2026-09-19T01:42:00.000Z",
+			endAt: "2026-09-19T02:25:00.000Z",
+		}]);
+	});
+
+	it("returns a safe service error when availability cannot be loaded", async () => {
+		mockRpc.mockResolvedValue({ data: null, error: { message: "private database detail" } });
+		const response = await GET();
+		expect(response.status).toBe(503);
+		expect(JSON.stringify(await response.json())).not.toContain("private database detail");
+	});
+});

--- a/app/api/pickup-windows/route.ts
+++ b/app/api/pickup-windows/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
+import type { CustomerPickupWindow } from "@/lib/pickupWindows";
+
+type PickupWindowRow = { id: string; start_at: string; end_at: string };
+
+export async function GET() {
+	const { data, error } = await getSupabaseAdmin().rpc("list_available_pickup_windows");
+	if (error) {
+		console.error("[pickup-windows] availability lookup failed", error);
+		return NextResponse.json({ error: "Pickup times are temporarily unavailable." }, { status: 503 });
+	}
+	const windows: CustomerPickupWindow[] = ((data ?? []) as PickupWindowRow[]).map((window) => ({
+		id: window.id,
+		startAt: window.start_at,
+		endAt: window.end_at,
+	}));
+	return NextResponse.json(windows, { headers: { "Cache-Control": "no-store" } });
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -6,6 +6,7 @@ import OrderSummary from "@/components/checkout/OrderSummary";
 import CheckoutForm, { CheckoutData } from "@/components/checkout/paymentTiles/CheckoutForm";
 import VenmoTile from "@/components/checkout/paymentTiles/VenmoTile";
 import type { PaymentMethod } from "@/lib/orderTypes";
+import { formatPickupWindow, type CustomerPickupWindow } from "@/lib/pickupWindows";
 
 export default function CheckoutPage() {
 	const router = useRouter();
@@ -13,7 +14,27 @@ export default function CheckoutPage() {
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("venmo");
+	const [pickupWindows, setPickupWindows] = useState<CustomerPickupWindow[]>([]);
+	const [pickupWindowId, setPickupWindowId] = useState("");
+	const [pickupLoading, setPickupLoading] = useState(true);
 	const orderPlacedRef = useRef(false);
+
+	async function loadPickupWindows() {
+		setPickupLoading(true);
+		const response = await fetch("/api/pickup-windows", { cache: "no-store" });
+		if (!response.ok) {
+			setPickupWindows([]);
+			setError("Pickup times are temporarily unavailable. Please try again.");
+			setPickupLoading(false);
+			return;
+		}
+		const available = await response.json();
+		setPickupWindows(Array.isArray(available) ? available : []);
+		setPickupWindowId((current) => available.some((window: CustomerPickupWindow) => window.id === current) ? current : "");
+		setPickupLoading(false);
+	}
+
+	useEffect(() => { void loadPickupWindows(); }, []);
 
 	useEffect(() => {
 		if (orderPlacedRef.current) return;
@@ -23,12 +44,16 @@ export default function CheckoutPage() {
 	}, [hydrated, items.length, router]);
 
 	async function submit(data: CheckoutData) {
-		if (!items.length) return;
+		if (!items.length || !pickupWindowId) {
+			setError("Choose an available pickup time.");
+			return;
+		}
 		setSubmitting(true);
 		setError(null);
 		const payload = {
 			customer: { name: data.name, email: data.email, phone: data.phone, notes: data.notes },
 			payment: { method: data.paymentMethod, venmoUser: data.venmoUser, note: data.paymentNote },
+			pickupWindowId,
 			items: items.map((item) => ({ productId: item.id, quantity: item.qty })),
 		};
 		const res = await fetch("/api/orders", {
@@ -37,7 +62,7 @@ export default function CheckoutPage() {
 			body: JSON.stringify(payload),
 		});
 		setSubmitting(false);
-		let json: { trackingToken?: string; error?: string };
+		let json: { trackingToken?: string; code?: string; error?: string };
 		try {
 			json = await res.json();
 		} catch {
@@ -45,6 +70,10 @@ export default function CheckoutPage() {
 		}
 		if (!res.ok) {
 			setError(json.error ?? "Order failed. Please try again.");
+			if (json.code === "PICKUP_WINDOW_UNAVAILABLE") {
+				setPickupWindowId("");
+				void loadPickupWindows();
+			}
 			return;
 		}
 		if (!json.trackingToken) {
@@ -61,6 +90,22 @@ export default function CheckoutPage() {
 			<h1 className="mb-6 font-display text-3xl font-semibold text-cocoa">Checkout</h1>
 
 			<div className="grid gap-6">
+				<section className="card-warm p-6 sm:p-8">
+					<h2 className="mb-2 font-display text-xl font-semibold text-cocoa">Pickup time</h2>
+					<p className="mb-4 text-sm text-sage">Choose a bakery pickup window. All times are Pacific Time.</p>
+					{pickupLoading ? <p className="text-sage">Loading pickup times...</p> : pickupWindows.length === 0 ? (
+						<p className="rounded-lg bg-berry/10 px-4 py-3 text-cocoa" role="status">No pickup times are currently available. Please check back soon.</p>
+					) : (
+						<label>
+							<span className="mb-1.5 block text-sm font-medium text-cocoa">Pickup window *</span>
+							<select value={pickupWindowId} onChange={(event) => setPickupWindowId(event.target.value)} required className="input-base">
+								<option value="">Select pickup time</option>
+								{pickupWindows.map((window) => <option key={window.id} value={window.id}>{formatPickupWindow(window)}</option>)}
+							</select>
+						</label>
+					)}
+				</section>
+
 				<section className="card-warm p-6 sm:p-8">
 					<h2 className="mb-4 font-display text-xl font-semibold text-cocoa">Contact & Payment</h2>
 					<CheckoutForm onSubmit={submit} onPaymentMethodChange={setPaymentMethod} />
@@ -90,7 +135,7 @@ export default function CheckoutPage() {
 					<button
 						type="submit"
 						form="checkout-form"
-						disabled={submitting || !items.length}
+						disabled={submitting || !items.length || pickupLoading || !pickupWindowId}
 						className="btn-primary mt-4"
 					>
 						{submitting ? "Submitting..." : "Place Order"}

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import type { PublicOrderTracking } from "@/lib/orderTypes";
 import { formatCurrency } from "@/lib/menuCatalog";
+import { formatPickupWindow } from "@/lib/pickupWindows";
 
 export default function OrderPage() {
 	const { id: token } = useParams<{ id: string }>();
@@ -68,6 +69,13 @@ export default function OrderPage() {
 				<span className="ml-4 text-sage">Payment:</span>{" "}
 				<strong className="text-cocoa">{order.payment.status}</strong>
 			</div>
+			{order.pickup && (
+				<div className="mb-6 rounded-lg border border-crust bg-wheat px-4 py-3 text-cocoa">
+					<span className="text-sage">Pickup:</span>{" "}
+					<strong>{formatPickupWindow(order.pickup)}</strong>
+					<span className="ml-2 text-sm text-sage">Pacific Time</span>
+				</div>
+			)}
 
 			<section>
 				{order.items.map((i, index) => (

--- a/components/admin/AdminNavigation.tsx
+++ b/components/admin/AdminNavigation.tsx
@@ -9,6 +9,8 @@ import {
 const links = [
 	{ href: "/admin/orders", label: "Orders", Icon: OrdersNavIcon },
 	{ href: "/admin/menu", label: "Menu", Icon: MenuNavIcon },
+	{ href: "/admin/inventory", label: "Inventory", Icon: MenuNavIcon },
+	{ href: "/admin/availability", label: "Pickup", Icon: OrdersNavIcon },
 	{ href: "/admin/menu?view=past", label: "Past Flavors", Icon: PastFlavorsNavIcon },
 ];
 

--- a/lib/notifications/channels.test.ts
+++ b/lib/notifications/channels.test.ts
@@ -10,6 +10,7 @@ const notification: OrderNotification = {
 		id: "ord_123", createdAt: "2026-09-10T18:00:00.000Z", fulfillmentStatus: "RECEIVED",
 		customer: { name: "Alice <Baker>", email: "alice@example.com", phone: "555-0100", notes: "Pickup after 4 & ring bell" },
 		payment: { method: "cash", status: "PENDING" },
+		pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 		items: [{ productId: "cake", name: "Chocolate & Vanilla", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
 		totals: { subtotalCents: 5000, totalCents: 5000 },
 	},
@@ -34,6 +35,7 @@ describe("notification channels", () => {
 		expect(message.text).toContain("Pickup after 4 & ring bell");
 		expect(message.text).toContain("Chocolate & Vanilla x 2 — $50.00");
 		expect(message.text).toContain("Payment: cash (PENDING)");
+		expect(message.text).toContain("Pickup: Friday, Sep 18 · 6:42 PM–7:25 PM Pacific Time");
 		expect(message.text).toContain("Admin orders: https://bakery.example/admin/orders");
 	});
 

--- a/lib/notifications/channels.ts
+++ b/lib/notifications/channels.ts
@@ -1,6 +1,7 @@
 import type {
 	EmailMessage, EmailProvider, NotificationChannel, OrderNotification, PushProvider, SmsProvider,
 } from "./types";
+import { formatPickupWindow } from "../pickupWindows";
 
 function currency(cents: number): string {
 	return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
@@ -26,6 +27,7 @@ function renderEmail(notification: OrderNotification, from: string, to: string):
 		`Email: ${order.customer.email}`,
 		order.customer.phone ? `Phone: ${order.customer.phone}` : undefined,
 		order.customer.notes ? `Customer notes / pickup information: ${order.customer.notes}` : undefined,
+		order.pickup ? `Pickup: ${formatPickupWindow(order.pickup, "short")} Pacific Time` : "Pickup: not specified on this order",
 		"",
 		"Items:",
 		...itemLines,
@@ -36,7 +38,6 @@ function renderEmail(notification: OrderNotification, from: string, to: string):
 		`Fulfillment: ${order.fulfillmentStatus}`,
 		order.payment.venmoUser ? `Venmo user: ${order.payment.venmoUser}` : undefined,
 		order.payment.note ? `Payment note: ${order.payment.note}` : undefined,
-		order.customer.notes ? undefined : "Pickup information: not specified on this order",
 		notification.adminUrl ? `Admin orders: ${notification.adminUrl}` : undefined,
 	].filter((line): line is string => line !== undefined);
 	const text = detailLines.join("\n");

--- a/lib/notifications/service.test.ts
+++ b/lib/notifications/service.test.ts
@@ -8,6 +8,7 @@ const order = {
 	fulfillmentStatus: "RECEIVED" as const,
 	payment: { method: "venmo" as const, status: "PAID" as const, venmoUser: "@alice" },
 	customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100", notes: "Friday pickup" },
+	pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 	items: [{ productId: "cake", name: "Chocolate Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
 	totals: { subtotalCents: 5000, totalCents: 5000 },
 };

--- a/lib/orderTracking.test.ts
+++ b/lib/orderTracking.test.ts
@@ -9,14 +9,17 @@ describe("public order tracking", () => {
 	it("returns authoritative snapshots without private payment or customer fields", () => {
 		const result = toPublicOrderTracking("IN_PROGRESS", {
 			payment: { method: "venmo", status: "PAID", venmoUser: "@private", note: "private" },
+			pickup: { windowId: "window-1", startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
 			totals: { subtotalCents: 5000, totalCents: 5000 },
 		});
 		expect(result).toEqual({
 			fulfillmentStatus: "IN_PROGRESS", payment: { method: "venmo", status: "PAID" },
+			pickup: { startAt: "2026-09-19T01:42:00.000Z", endAt: "2026-09-19T02:25:00.000Z" },
 			items: [{ productId: "cake", name: "Cake", unitPriceCents: 2500, quantity: 2, lineTotalCents: 5000 }],
 			totals: { subtotalCents: 5000, totalCents: 5000 },
 		});
 		expect(result.payment).not.toHaveProperty("venmoUser");
+		expect(result.pickup).not.toHaveProperty("windowId");
 	});
 });

--- a/lib/orderTracking.ts
+++ b/lib/orderTracking.ts
@@ -13,11 +13,12 @@ export function isValidTrackingToken(value: string): boolean {
 
 export function toPublicOrderTracking(
 	fulfillmentStatus: FulfillmentStatus,
-	payload: Pick<OrderRecord, "payment" | "items" | "totals">,
+	payload: Pick<OrderRecord, "payment" | "pickup" | "items" | "totals">,
 ): PublicOrderTracking {
 	return {
 		fulfillmentStatus,
 		payment: { method: payload.payment.method, status: payload.payment.status },
+		...(payload.pickup && { pickup: { startAt: payload.pickup.startAt, endAt: payload.pickup.endAt } }),
 		items: payload.items.map((item) => ({
 			productId: item.productId,
 			name: item.name,

--- a/lib/orderTypes.ts
+++ b/lib/orderTypes.ts
@@ -10,15 +10,24 @@ export type OrderItem = {
 	lineTotalCents: number;
 };
 
+export type PickupSnapshot = {
+	windowId: string;
+	startAt: string;
+	endAt: string;
+};
+
 export type OrderRecord = {
 	id: string;
 	createdAt: string;
 	fulfillmentStatus: FulfillmentStatus;
 	payment: { method: PaymentMethod; status: PaymentStatus; venmoUser?: string; note?: string };
 	customer: { name: string; email: string; phone?: string; notes?: string };
+	pickup?: PickupSnapshot;
 	items: OrderItem[];
 	totals: { subtotalCents: number; totalCents: number };
 };
 
-export type PublicOrderTracking = Pick<OrderRecord, "fulfillmentStatus" | "payment" | "items" | "totals">;
+export type PublicOrderTracking = Pick<OrderRecord, "fulfillmentStatus" | "payment" | "items" | "totals"> & {
+	pickup?: Pick<PickupSnapshot, "startAt" | "endAt">;
+};
 export type AdminOrderRecord = OrderRecord & { trackingToken: string | null };

--- a/lib/orderValidation.test.ts
+++ b/lib/orderValidation.test.ts
@@ -4,6 +4,7 @@ import { validateOrderPayload } from "./orderValidation";
 const validPayload = {
 	customer: { name: "Alice Baker", email: "alice@example.com" },
 	payment: { method: "cash" },
+	pickupWindowId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
 	items: [{ productId: "cake", quantity: 1 }],
 };
 
@@ -13,11 +14,32 @@ describe("validateOrderPayload", () => {
 			...validPayload,
 			customer: { ...validPayload.customer, name: "  Alice Baker  ", phone: " 555-0100 " },
 		});
-		expect(result).toEqual({ ok: true, data: {
+			expect(result).toEqual({ ok: true, data: {
 			customer: { name: "Alice Baker", email: "alice@example.com", phone: "555-0100" },
 			payment: { method: "cash" },
+			pickupWindowId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
 			items: [{ productId: "cake", quantity: 1 }],
 		} });
+	});
+
+	it("requires a pickup-window ID and ignores customer-supplied pickup timestamps", () => {
+		expect(validateOrderPayload({ ...validPayload, pickupWindowId: undefined })).toMatchObject({
+			ok: false,
+			code: "INVALID_PICKUP_WINDOW",
+		});
+		expect(validateOrderPayload({ ...validPayload, pickupWindowId: "not-a-uuid" })).toMatchObject({
+			ok: false,
+			code: "INVALID_PICKUP_WINDOW",
+		});
+		const result = validateOrderPayload({
+			...validPayload,
+			pickup: { startAt: "1900-01-01T00:00:00Z", endAt: "2999-01-01T00:00:00Z" },
+		});
+		expect(result).toMatchObject({
+			ok: true,
+			data: { pickupWindowId: validPayload.pickupWindowId },
+		});
+		expect(JSON.stringify(result)).not.toContain("1900-01-01");
 	});
 
 	it("accepts Zelle with an optional note", () => {

--- a/lib/orderValidation.ts
+++ b/lib/orderValidation.ts
@@ -7,10 +7,13 @@ const LIMITS = { name: 200, email: 254, phone: 30, notes: 2000, productId: 100, 
 type TrustedOrderRequest = {
 	customer: { name: string; email: string; phone?: string; notes?: string };
 	payment: { method: PaymentMethod; venmoUser?: string; note?: string };
+	pickupWindowId: string;
 	items: { productId: string; quantity: number }[];
 };
 
-type ValidationError = { ok: false; code: "INVALID_ORDER" | "INVALID_QUANTITY" | "INVALID_PAYMENT_METHOD"; error: string };
+type ValidationError = { ok: false; code: "INVALID_ORDER" | "INVALID_QUANTITY" | "INVALID_PAYMENT_METHOD" | "INVALID_PICKUP_WINDOW"; error: string };
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function optionalString(value: unknown, field: string, max: number): string | ValidationError | undefined {
 	if (value === undefined || value === null || value === "") return undefined;
@@ -23,6 +26,9 @@ export function validateOrderPayload(body: unknown): { ok: true; data: TrustedOr
 	const input = body as Record<string, unknown>;
 	if (!input.customer || typeof input.customer !== "object") return { ok: false, code: "INVALID_ORDER", error: "Customer information is required" };
 	if (!input.payment || typeof input.payment !== "object") return { ok: false, code: "INVALID_PAYMENT_METHOD", error: "Payment method is required" };
+	if (typeof input.pickupWindowId !== "string" || !UUID_PATTERN.test(input.pickupWindowId)) {
+		return { ok: false, code: "INVALID_PICKUP_WINDOW", error: "Choose an available pickup time." };
+	}
 	if (!Array.isArray(input.items) || input.items.length === 0 || input.items.length > MAX_ITEMS) return { ok: false, code: "INVALID_ORDER", error: `Order must contain between 1 and ${MAX_ITEMS} items` };
 
 	const customerInput = input.customer as Record<string, unknown>;
@@ -60,6 +66,7 @@ export function validateOrderPayload(body: unknown): { ok: true; data: TrustedOr
 	return { ok: true, data: {
 		customer: { name, email, ...(phone && { phone }), ...(notes && { notes }) },
 		payment: { method, ...(method === "venmo" && venmoUser && { venmoUser }), ...(note && { note }) },
+		pickupWindowId: input.pickupWindowId,
 		items: [...quantities].map(([productId, quantity]) => ({ productId, quantity })),
 	} };
 }

--- a/lib/pickupWindows.test.ts
+++ b/lib/pickupWindows.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatPickupWindow,
+	parsePacificDateTime,
+} from "./pickupWindows";
+
+describe("pickup windows", () => {
+	it("accepts minute-precise Pacific local times and formats them in Pacific Time", () => {
+		const startAt = parsePacificDateTime("2026-09-18", "18:42");
+		const endAt = parsePacificDateTime("2026-09-18", "19:25");
+
+		expect(startAt).toBe("2026-09-19T01:42:00.000Z");
+		expect(endAt).toBe("2026-09-19T02:25:00.000Z");
+		expect(formatPickupWindow({ startAt, endAt }, "short")).toBe(
+			"Friday, Sep 18 · 6:42 PM–7:25 PM",
+		);
+	});
+
+	it("uses PST/PDT from America/Los_Angeles instead of a fixed UTC offset", () => {
+		expect(parsePacificDateTime("2026-01-15", "18:42")).toBe("2026-01-16T02:42:00.000Z");
+		expect(parsePacificDateTime("2026-07-15", "18:42")).toBe("2026-07-16T01:42:00.000Z");
+	});
+
+	it("rejects malformed, impossible, and DST-skipped local times", () => {
+		expect(() => parsePacificDateTime("2026-02-30", "18:42")).toThrow("valid date");
+		expect(() => parsePacificDateTime("2026-03-08", "02:30")).toThrow("valid Pacific time");
+		expect(() => parsePacificDateTime("2026-09-18", "18:60")).toThrow("valid time");
+	});
+
+});

--- a/lib/pickupWindows.ts
+++ b/lib/pickupWindows.ts
@@ -1,0 +1,134 @@
+export const BAKERY_TIME_ZONE = "America/Los_Angeles";
+export type PickupWindow = {
+	id: string;
+	startAt: string;
+	endAt: string;
+	enabled: boolean;
+};
+
+export type CustomerPickupWindow = Pick<PickupWindow, "id" | "startAt" | "endAt">;
+
+type PickupTimes = Pick<PickupWindow, "startAt" | "endAt">;
+type LocalParts = { year: number; month: number; day: number; hour: number; minute: number };
+
+const pacificPartsFormatter = new Intl.DateTimeFormat("en-US", {
+	timeZone: BAKERY_TIME_ZONE,
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+	hour: "2-digit",
+	minute: "2-digit",
+	second: "2-digit",
+	hourCycle: "h23",
+});
+
+function localParts(date: Date): LocalParts & { second: number } {
+	const parts = Object.fromEntries(
+		pacificPartsFormatter.formatToParts(date)
+			.filter((part) => part.type !== "literal")
+			.map((part) => [part.type, Number(part.value)]),
+	);
+	return {
+		year: parts.year,
+		month: parts.month,
+		day: parts.day,
+		hour: parts.hour,
+		minute: parts.minute,
+		second: parts.second,
+	};
+}
+
+function sameLocalMinute(actual: ReturnType<typeof localParts>, expected: LocalParts): boolean {
+	return actual.year === expected.year
+		&& actual.month === expected.month
+		&& actual.day === expected.day
+		&& actual.hour === expected.hour
+		&& actual.minute === expected.minute;
+}
+
+function offsetMilliseconds(date: Date): number {
+	const parts = localParts(date);
+	return Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second)
+		- date.getTime();
+}
+
+/** Converts owner-entered bakery-local date/time fields to an unambiguous UTC timestamp. */
+export function parsePacificDateTime(dateValue: string, timeValue: string): string {
+	const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateValue);
+	if (!dateMatch) throw new Error("Enter a valid date.");
+	const timeMatch = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(timeValue);
+	if (!timeMatch) throw new Error("Enter a valid time.");
+
+	const expected: LocalParts = {
+		year: Number(dateMatch[1]),
+		month: Number(dateMatch[2]),
+		day: Number(dateMatch[3]),
+		hour: Number(timeMatch[1]),
+		minute: Number(timeMatch[2]),
+	};
+	const localEpoch = Date.UTC(expected.year, expected.month - 1, expected.day, expected.hour, expected.minute);
+	const calendarCheck = new Date(Date.UTC(expected.year, expected.month - 1, expected.day));
+	if (calendarCheck.getUTCFullYear() !== expected.year
+		|| calendarCheck.getUTCMonth() + 1 !== expected.month
+		|| calendarCheck.getUTCDate() !== expected.day) {
+		throw new Error("Enter a valid date.");
+	}
+
+	let candidate = new Date(localEpoch);
+	for (let iteration = 0; iteration < 3; iteration += 1) {
+		candidate = new Date(localEpoch - offsetMilliseconds(candidate));
+	}
+	if (!sameLocalMinute(localParts(candidate), expected)) {
+		throw new Error("Enter a valid Pacific time.");
+	}
+	return candidate.toISOString();
+}
+
+export function validatePickupWindowTimes(startAt: string, endAt: string, now = new Date()): string | null {
+	const start = new Date(startAt);
+	const end = new Date(endAt);
+	if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) return "Enter valid pickup times.";
+	if (end.getTime() <= start.getTime()) return "End time must be after start time.";
+	if (start.getTime() <= now.getTime()) return "Pickup start must be in the future.";
+	return null;
+}
+
+export function parsePickupWindowInput(body: Record<string, unknown>, now = new Date()) {
+	if (typeof body.date !== "string" || typeof body.startTime !== "string" || typeof body.endTime !== "string") {
+		return { error: "Date, start time, and end time are required." } as const;
+	}
+	try {
+		const startAt = parsePacificDateTime(body.date, body.startTime);
+		const endAt = parsePacificDateTime(body.date, body.endTime);
+		const error = validatePickupWindowTimes(startAt, endAt, now);
+		return error ? ({ error } as const) : ({ startAt, endAt } as const);
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : "Enter valid pickup times." } as const;
+	}
+}
+
+export function toPacificFormValues(timestamp: string): { date: string; time: string } {
+	const parts = localParts(new Date(timestamp));
+	const pad = (value: number) => String(value).padStart(2, "0");
+	return {
+		date: `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`,
+		time: `${pad(parts.hour)}:${pad(parts.minute)}`,
+	};
+}
+
+export function formatPickupWindow(window: PickupTimes, style: "short" | "long" = "long"): string {
+	const start = new Date(window.startAt);
+	const end = new Date(window.endAt);
+	const date = new Intl.DateTimeFormat("en-US", {
+		timeZone: BAKERY_TIME_ZONE,
+		weekday: "long",
+		month: style === "short" ? "short" : "long",
+		day: "numeric",
+	}).format(start);
+	const timeFormatter = new Intl.DateTimeFormat("en-US", {
+		timeZone: BAKERY_TIME_ZONE,
+		hour: "numeric",
+		minute: "2-digit",
+	});
+	return `${date} · ${timeFormatter.format(start)}–${timeFormatter.format(end)}`;
+}

--- a/scripts/test-inventory-db.sh
+++ b/scripts/test-inventory-db.sh
@@ -61,8 +61,8 @@ if [[ "$demand_count" -ne 2 ]]; then
     exit 1
 fi
 
-reservation_one="SELECT public.create_authoritative_order('race_1','track_race_1','{\"name\":\"Race One\",\"email\":\"one@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"
-reservation_two="SELECT public.create_authoritative_order('race_2','track_race_2','{\"name\":\"Race Two\",\"email\":\"two@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb);"
+reservation_one="SELECT public.create_authoritative_order('race_1','track_race_1','{\"name\":\"Race One\",\"email\":\"one@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb,'11111111-1111-4111-8111-111111111111');"
+reservation_two="SELECT public.create_authoritative_order('race_2','track_race_2','{\"name\":\"Race Two\",\"email\":\"two@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cookie_chocolatechip\",\"quantity\":1}]'::jsonb,'11111111-1111-4111-8111-111111111111');"
 
 docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$reservation_one" >"$results_dir/one" 2>&1 &
 pid_one=$!
@@ -86,7 +86,7 @@ fi
 # starting stock 5 becomes 5 after one decrement and one increment.
 docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" \
     -c "UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_vanilla'; DELETE FROM public.orders WHERE id LIKE 'admin_race_%';" >/dev/null
-admin_race_order="SELECT public.create_authoritative_order('admin_race_order','track_admin_race','{\"name\":\"Race Customer\",\"email\":\"race@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cakepop_vanilla\",\"quantity\":1}]'::jsonb);"
+admin_race_order="SELECT public.create_authoritative_order('admin_race_order','track_admin_race','{\"name\":\"Race Customer\",\"email\":\"race@example.com\"}'::jsonb,'{\"method\":\"cash\"}'::jsonb,'[{\"productId\":\"cakepop_vanilla\",\"quantity\":1}]'::jsonb,'11111111-1111-4111-8111-111111111111');"
 docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "$admin_race_order" >"$results_dir/order" 2>&1 &
 pid_order=$!
 docker exec "$container" psql -v ON_ERROR_STOP=1 -U postgres -d "$database" -c "SELECT public.adjust_product_inventory('cakepop_vanilla', 1);" >"$results_dir/admin" 2>&1 &

--- a/supabase/migrations/20260910183717_add_pickup_windows.sql
+++ b/supabase/migrations/20260910183717_add_pickup_windows.sql
@@ -1,0 +1,268 @@
+CREATE TABLE public.pickup_windows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    start_at TIMESTAMPTZ NOT NULL,
+    end_at TIMESTAMPTZ NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT pickup_windows_end_after_start CHECK (end_at > start_at)
+);
+
+CREATE INDEX pickup_windows_start_at_idx ON public.pickup_windows (start_at);
+
+ALTER TABLE public.pickup_windows ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.pickup_windows FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.pickup_windows TO service_role;
+
+CREATE FUNCTION public.pickup_window_is_selectable(
+    p_start_at TIMESTAMPTZ,
+    p_end_at TIMESTAMPTZ,
+    p_enabled BOOLEAN,
+    p_at TIMESTAMPTZ DEFAULT now()
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+    SELECT p_enabled IS TRUE
+        AND p_start_at IS NOT NULL
+        AND p_end_at IS NOT NULL
+        AND p_end_at > p_start_at
+        AND p_start_at >= p_at + INTERVAL '15 minutes';
+$$;
+
+CREATE FUNCTION public.list_available_pickup_windows(p_at TIMESTAMPTZ DEFAULT now())
+RETURNS TABLE (id UUID, start_at TIMESTAMPTZ, end_at TIMESTAMPTZ)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+    SELECT pickup.id, pickup.start_at, pickup.end_at
+    FROM public.pickup_windows AS pickup
+    WHERE public.pickup_window_is_selectable(pickup.start_at, pickup.end_at, pickup.enabled, p_at)
+    ORDER BY pickup.start_at, pickup.end_at, pickup.id;
+$$;
+
+CREATE FUNCTION public.replace_pickup_window(
+    p_pickup_window_id UUID,
+    p_start_at TIMESTAMPTZ,
+    p_end_at TIMESTAMPTZ,
+    p_enabled BOOLEAN DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    existing public.pickup_windows%ROWTYPE;
+    replacement public.pickup_windows%ROWTYPE;
+BEGIN
+    IF p_start_at IS NULL OR p_end_at IS NULL OR p_end_at <= p_start_at OR p_start_at <= now() THEN
+        RAISE EXCEPTION 'INVALID_PICKUP_WINDOW';
+    END IF;
+
+    SELECT * INTO existing
+    FROM public.pickup_windows
+    WHERE id = p_pickup_window_id
+    FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'PICKUP_WINDOW_NOT_FOUND'; END IF;
+
+    UPDATE public.pickup_windows
+    SET enabled = false, updated_at = now()
+    WHERE id = p_pickup_window_id;
+
+    INSERT INTO public.pickup_windows (start_at, end_at, enabled)
+    VALUES (p_start_at, p_end_at, COALESCE(p_enabled, existing.enabled))
+    RETURNING * INTO replacement;
+
+    RETURN to_jsonb(replacement);
+END;
+$$;
+
+DROP FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB);
+
+CREATE FUNCTION public.create_authoritative_order(
+    p_order_id TEXT,
+    p_tracking_token TEXT,
+    p_customer JSONB,
+    p_payment JSONB,
+    p_items JSONB,
+    p_pickup_window_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+    item JSONB;
+    requested RECORD;
+    product RECORD;
+    pickup_window RECORD;
+    current_quantity INTEGER;
+    changed_rows INTEGER;
+    numeric_quantity NUMERIC;
+    subtotal_cents BIGINT := 0;
+    order_items JSONB := '[]'::jsonb;
+    payment_snapshot JSONB;
+    pickup_snapshot JSONB;
+    order_snapshot JSONB;
+    created_at TIMESTAMPTZ;
+BEGIN
+    IF jsonb_typeof(p_customer) IS DISTINCT FROM 'object' THEN
+        RAISE EXCEPTION 'INVALID_ORDER';
+    END IF;
+    IF jsonb_typeof(p_payment) IS DISTINCT FROM 'object'
+        OR p_payment->>'method' NOT IN ('cash', 'venmo', 'zelle') THEN
+        RAISE EXCEPTION 'INVALID_PAYMENT_METHOD';
+    END IF;
+    IF p_payment->>'method' = 'venmo' AND btrim(COALESCE(p_payment->>'venmoUser', '')) = '' THEN
+        RAISE EXCEPTION 'INVALID_PAYMENT_METHOD';
+    END IF;
+    IF jsonb_typeof(p_items) IS DISTINCT FROM 'array' OR jsonb_array_length(p_items) = 0 THEN
+        RAISE EXCEPTION 'INVALID_QUANTITY';
+    END IF;
+    IF p_pickup_window_id IS NULL THEN
+        RAISE EXCEPTION 'PICKUP_WINDOW_UNAVAILABLE';
+    END IF;
+
+    SELECT pickup.id, pickup.start_at, pickup.end_at, pickup.enabled
+    INTO pickup_window
+    FROM public.pickup_windows AS pickup
+    WHERE pickup.id = p_pickup_window_id
+    FOR SHARE;
+
+    IF NOT FOUND OR NOT public.pickup_window_is_selectable(
+        pickup_window.start_at,
+        pickup_window.end_at,
+        pickup_window.enabled,
+        clock_timestamp()
+    ) THEN
+        RAISE EXCEPTION 'PICKUP_WINDOW_UNAVAILABLE';
+    END IF;
+
+    FOR item IN SELECT value FROM jsonb_array_elements(p_items)
+    LOOP
+        IF jsonb_typeof(item) IS DISTINCT FROM 'object'
+            OR jsonb_typeof(item->'productId') IS DISTINCT FROM 'string'
+            OR btrim(item->>'productId') = ''
+            OR jsonb_typeof(item->'quantity') IS DISTINCT FROM 'number' THEN
+            RAISE EXCEPTION 'INVALID_QUANTITY';
+        END IF;
+        numeric_quantity := (item->>'quantity')::numeric;
+        IF numeric_quantity <= 0 OR numeric_quantity <> trunc(numeric_quantity) OR numeric_quantity > 2147483647 THEN
+            RAISE EXCEPTION 'INVALID_QUANTITY';
+        END IF;
+    END LOOP;
+
+    FOR requested IN
+        SELECT value->>'productId' AS product_id, SUM((value->>'quantity')::bigint) AS quantity
+        FROM jsonb_array_elements(p_items)
+        GROUP BY value->>'productId'
+        ORDER BY value->>'productId'
+    LOOP
+        IF requested.quantity > 2147483647 THEN RAISE EXCEPTION 'INVALID_QUANTITY'; END IF;
+
+        SELECT id, name, price_cents, max_per_order, is_archived
+        INTO product
+        FROM public.products
+        WHERE id = requested.product_id
+        FOR SHARE;
+
+        IF NOT FOUND THEN RAISE EXCEPTION 'INVALID_PRODUCT'; END IF;
+        IF product.is_archived THEN RAISE EXCEPTION 'PRODUCT_UNAVAILABLE'; END IF;
+        IF requested.quantity > product.max_per_order THEN RAISE EXCEPTION 'MAX_QUANTITY_EXCEEDED'; END IF;
+
+        SELECT quantity_on_hand INTO current_quantity
+        FROM public.product_inventory
+        WHERE product_id = requested.product_id
+        FOR UPDATE;
+
+        IF NOT FOUND OR current_quantity < requested.quantity THEN RAISE EXCEPTION 'OUT_OF_STOCK'; END IF;
+
+        UPDATE public.product_inventory
+        SET quantity_on_hand = quantity_on_hand - requested.quantity::integer
+        WHERE product_id = requested.product_id AND quantity_on_hand >= requested.quantity;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+        IF changed_rows <> 1 THEN RAISE EXCEPTION 'OUT_OF_STOCK'; END IF;
+
+        subtotal_cents := subtotal_cents + (product.price_cents::bigint * requested.quantity);
+        order_items := order_items || jsonb_build_array(jsonb_build_object(
+            'productId', product.id,
+            'name', product.name,
+            'unitPriceCents', product.price_cents,
+            'quantity', requested.quantity,
+            'lineTotalCents', product.price_cents::bigint * requested.quantity
+        ));
+    END LOOP;
+
+    created_at := clock_timestamp();
+    IF NOT public.pickup_window_is_selectable(
+        pickup_window.start_at,
+        pickup_window.end_at,
+        pickup_window.enabled,
+        created_at
+    ) THEN
+        RAISE EXCEPTION 'PICKUP_WINDOW_UNAVAILABLE';
+    END IF;
+
+    payment_snapshot := jsonb_strip_nulls(jsonb_build_object(
+        'method', p_payment->>'method',
+        'status', 'PENDING',
+        'venmoUser', p_payment->'venmoUser',
+        'note', p_payment->'note'
+    ));
+    pickup_snapshot := jsonb_build_object(
+        'windowId', pickup_window.id,
+        'startAt', pickup_window.start_at,
+        'endAt', pickup_window.end_at
+    );
+    order_snapshot := jsonb_build_object(
+        'id', p_order_id,
+        'createdAt', created_at,
+        'fulfillmentStatus', 'RECEIVED',
+        'payment', payment_snapshot,
+        'customer', p_customer,
+        'pickup', pickup_snapshot,
+        'items', order_items,
+        'totals', jsonb_build_object('subtotalCents', subtotal_cents, 'totalCents', subtotal_cents)
+    );
+
+    INSERT INTO public.orders (id, tracking_token, status, payload, created_at)
+    VALUES (p_order_id, p_tracking_token, 'RECEIVED', order_snapshot, created_at);
+
+    RETURN jsonb_build_object('id', p_order_id, 'order', order_snapshot);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pickup_window_is_selectable(TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN, TIMESTAMPTZ)
+FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_available_pickup_windows(TIMESTAMPTZ)
+FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.replace_pickup_window(UUID, TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN)
+FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB, UUID)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.pickup_window_is_selectable(TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN, TIMESTAMPTZ)
+TO service_role;
+GRANT EXECUTE ON FUNCTION public.list_available_pickup_windows(TIMESTAMPTZ)
+TO service_role;
+GRANT EXECUTE ON FUNCTION public.replace_pickup_window(UUID, TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN)
+TO service_role;
+GRANT EXECUTE ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB, UUID)
+TO service_role;
+
+COMMENT ON TABLE public.pickup_windows
+IS 'Concrete Pacific bakery pickup windows. Order payloads retain immutable pickup snapshots.';
+COMMENT ON FUNCTION public.pickup_window_is_selectable(TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN, TIMESTAMPTZ)
+IS 'Single authoritative enabled, validity, and inclusive 15-minute lead-time rule.';
+COMMENT ON FUNCTION public.list_available_pickup_windows(TIMESTAMPTZ)
+IS 'Returns chronologically sorted customer-selectable pickup windows to the server role.';
+COMMENT ON FUNCTION public.replace_pickup_window(UUID, TIMESTAMPTZ, TIMESTAMPTZ, BOOLEAN)
+IS 'Atomically disables an edited window and creates a replacement ID so stale checkout selections fail.';
+COMMENT ON FUNCTION public.create_authoritative_order(TEXT, TEXT, JSONB, JSONB, JSONB, UUID)
+IS 'Atomically validates pickup, catalog, and stock; reserves inventory; and stores immutable snapshots.';

--- a/supabase/tests/admin_catalog.sql
+++ b/supabase/tests/admin_catalog.sql
@@ -5,6 +5,10 @@ BEGIN
 END;
 $$;
 
+INSERT INTO public.pickup_windows (id, start_at, end_at, enabled)
+VALUES ('11111111-1111-4111-8111-111111111111', '2099-09-18T18:42:00-07:00', '2099-09-18T19:25:00-07:00', true)
+ON CONFLICT (id) DO NOTHING;
+
 SELECT pg_temp.assert_catalog(
     EXISTS (SELECT 1 FROM public.products WHERE id = 'cakepop_chocolate')
     AND EXISTS (SELECT 1 FROM public.categories WHERE id = 'cakepops'),
@@ -43,7 +47,8 @@ SELECT public.create_authoritative_order(
     'track_admin_catalog_history',
     '{"name":"Catalog Test","email":"catalog@example.com"}'::jsonb,
     '{"method":"cash"}'::jsonb,
-    '[{"productId":"00000000-0000-4000-8000-000000000011","quantity":1}]'::jsonb
+    '[{"productId":"00000000-0000-4000-8000-000000000011","quantity":1}]'::jsonb,
+    '11111111-1111-4111-8111-111111111111'
 );
 UPDATE public.products SET is_archived = true WHERE id = '00000000-0000-4000-8000-000000000011';
 UPDATE public.products SET is_archived = false WHERE id = '00000000-0000-4000-8000-000000000011';

--- a/supabase/tests/current_product_inventory.sql
+++ b/supabase/tests/current_product_inventory.sql
@@ -5,12 +5,16 @@ BEGIN
 END;
 $$;
 
+INSERT INTO public.pickup_windows (id, start_at, end_at, enabled)
+VALUES ('11111111-1111-4111-8111-111111111111', '2099-09-18T18:42:00-07:00', '2099-09-18T19:25:00-07:00', true)
+ON CONFLICT (id) DO NOTHING;
+
 CREATE FUNCTION pg_temp.place(test_id TEXT, payment JSONB, items JSONB)
 RETURNS JSONB LANGUAGE sql AS $$
     SELECT public.create_authoritative_order(
         test_id, 'track_' || test_id,
         '{"name":"Test Customer","email":"test@example.com"}'::jsonb,
-        payment, items
+        payment, items, '11111111-1111-4111-8111-111111111111'
     );
 $$;
 

--- a/supabase/tests/pickup_windows.sql
+++ b/supabase/tests/pickup_windows.sql
@@ -1,0 +1,148 @@
+CREATE FUNCTION pg_temp.assert_pickup(condition BOOLEAN, message TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+BEGIN
+    IF NOT condition THEN RAISE EXCEPTION 'assertion failed: %', message; END IF;
+END;
+$$;
+
+SELECT pg_temp.assert_pickup(
+    (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.pickup_windows'::regclass)
+    AND NOT has_table_privilege('anon', 'public.pickup_windows', 'SELECT')
+    AND NOT has_table_privilege('authenticated', 'public.pickup_windows', 'SELECT')
+    AND has_table_privilege('service_role', 'public.pickup_windows', 'SELECT'),
+    'pickup windows are private and server-managed'
+);
+SELECT pg_temp.assert_pickup(
+    NOT has_function_privilege('anon', 'public.list_available_pickup_windows(timestamptz)', 'EXECUTE')
+    AND NOT has_function_privilege('authenticated', 'public.list_available_pickup_windows(timestamptz)', 'EXECUTE')
+    AND has_function_privilege('service_role', 'public.list_available_pickup_windows(timestamptz)', 'EXECUTE'),
+    'customer-safe availability is exposed only through the server endpoint'
+);
+
+SELECT pg_temp.assert_pickup(
+    public.pickup_window_is_selectable(
+        '2026-09-18T14:00:00-07:00', '2026-09-18T18:00:00-07:00', true, '2026-09-18T13:45:00-07:00'
+    ),
+    'exactly fifteen minutes before start is selectable'
+);
+SELECT pg_temp.assert_pickup(
+    NOT public.pickup_window_is_selectable(
+        '2026-09-18T14:00:00-07:00', '2026-09-18T18:00:00-07:00', true, '2026-09-18T13:45:00.001-07:00'
+    ),
+    'less than fifteen minutes before start is not selectable'
+);
+SELECT pg_temp.assert_pickup(
+    NOT public.pickup_window_is_selectable(
+        '2026-09-18T14:00:00-07:00', '2026-09-18T18:00:00-07:00', false, '2026-09-18T13:00:00-07:00'
+    )
+    AND NOT public.pickup_window_is_selectable(
+        '2026-09-18T12:00:00-07:00', '2026-09-18T13:00:00-07:00', true, '2026-09-18T13:00:00-07:00'
+    ),
+    'disabled and past windows are not selectable'
+);
+
+DO $$ BEGIN
+    BEGIN
+        INSERT INTO public.pickup_windows (start_at, end_at) VALUES (now() + interval '1 day', now() + interval '1 day');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END $$;
+
+SELECT pg_temp.assert_pickup(
+    ('2026-07-15 18:42'::timestamp AT TIME ZONE 'America/Los_Angeles') = '2026-07-16T01:42:00Z'::timestamptz
+    AND ('2026-01-15 18:42'::timestamp AT TIME ZONE 'America/Los_Angeles') = '2026-01-16T02:42:00Z'::timestamptz,
+    'Pacific conversion follows PDT and PST independently of session timezone'
+);
+
+INSERT INTO public.pickup_windows (id, start_at, end_at, enabled) VALUES
+    ('22222222-2222-4222-8222-222222222222', now() + interval '2 days 42 minutes', now() + interval '2 days 85 minutes', true),
+    ('33333333-3333-4333-8333-333333333333', now() + interval '2 days', now() + interval '2 days 1 hour', false),
+    ('44444444-4444-4444-8444-444444444444', now() - interval '2 hours', now() - interval '1 hour', true),
+    ('55555555-5555-4555-8555-555555555555', now() + interval '14 minutes', now() + interval '1 hour', true)
+ON CONFLICT (id) DO UPDATE SET start_at = EXCLUDED.start_at, end_at = EXCLUDED.end_at, enabled = EXCLUDED.enabled;
+
+SELECT pg_temp.assert_pickup(
+    EXISTS (SELECT 1 FROM public.list_available_pickup_windows(now()) WHERE id = '22222222-2222-4222-8222-222222222222')
+    AND NOT EXISTS (SELECT 1 FROM public.list_available_pickup_windows(now()) WHERE id IN (
+        '33333333-3333-4333-8333-333333333333',
+        '44444444-4444-4444-8444-444444444444',
+        '55555555-5555-4555-8555-555555555555'
+    )),
+    'customer availability includes only enabled future windows with fifteen minutes remaining'
+);
+
+UPDATE public.product_inventory SET quantity_on_hand = 5 WHERE product_id = 'cakepop_chocolate';
+
+CREATE FUNCTION pg_temp.place_pickup(test_id TEXT, window_id UUID)
+RETURNS JSONB LANGUAGE sql AS $$
+    SELECT public.create_authoritative_order(
+        test_id,
+        'track_' || test_id,
+        '{"name":"Pickup Test","email":"pickup@example.com"}'::jsonb,
+        '{"method":"cash"}'::jsonb,
+        '[{"productId":"cakepop_chocolate","quantity":1}]'::jsonb,
+        window_id
+    );
+$$;
+
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place_pickup('pickup_missing', NULL);
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PICKUP_WINDOW_UNAVAILABLE%' THEN RAISE; END IF; END;
+END $$;
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place_pickup('pickup_unknown', '99999999-9999-4999-8999-999999999999');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PICKUP_WINDOW_UNAVAILABLE%' THEN RAISE; END IF; END;
+END $$;
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place_pickup('pickup_disabled', '33333333-3333-4333-8333-333333333333');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PICKUP_WINDOW_UNAVAILABLE%' THEN RAISE; END IF; END;
+END $$;
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place_pickup('pickup_cutoff', '55555555-5555-4555-8555-555555555555');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PICKUP_WINDOW_UNAVAILABLE%' THEN RAISE; END IF; END;
+END $$;
+
+SELECT pg_temp.assert_pickup(
+    (SELECT quantity_on_hand = 5 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
+    AND NOT EXISTS (SELECT 1 FROM public.orders WHERE id IN ('pickup_missing', 'pickup_unknown', 'pickup_disabled', 'pickup_cutoff')),
+    'invalid or stale pickup requests create no order and consume no inventory'
+);
+
+SELECT pg_temp.place_pickup('pickup_snapshot', '22222222-2222-4222-8222-222222222222');
+CREATE TEMP TABLE original_pickup_snapshot AS
+SELECT payload->'pickup' AS pickup FROM public.orders WHERE id = 'pickup_snapshot';
+SELECT public.replace_pickup_window(
+    '22222222-2222-4222-8222-222222222222',
+    now() + interval '3 days 42 minutes',
+    now() + interval '3 days 85 minutes'
+);
+SELECT pg_temp.assert_pickup(
+    (SELECT orders.payload->'pickup' = original.pickup
+     FROM public.orders AS orders CROSS JOIN original_pickup_snapshot AS original
+     WHERE orders.id = 'pickup_snapshot')
+    AND (SELECT payload->'pickup'->>'windowId' = '22222222-2222-4222-8222-222222222222'
+         FROM public.orders WHERE id = 'pickup_snapshot')
+    AND (SELECT enabled = false FROM public.pickup_windows WHERE id = '22222222-2222-4222-8222-222222222222'),
+    'editing and disabling availability does not change the historical order snapshot'
+);
+
+DO $$ BEGIN
+    BEGIN
+        PERFORM pg_temp.place_pickup('pickup_stale_edit', '22222222-2222-4222-8222-222222222222');
+        RAISE EXCEPTION 'unexpected success';
+    EXCEPTION WHEN OTHERS THEN IF SQLERRM = 'unexpected success' OR SQLERRM NOT LIKE 'PICKUP_WINDOW_UNAVAILABLE%' THEN RAISE; END IF; END;
+END $$;
+SELECT pg_temp.assert_pickup(
+    (SELECT quantity_on_hand = 4 FROM public.product_inventory WHERE product_id = 'cakepop_chocolate')
+    AND NOT EXISTS (SELECT 1 FROM public.orders WHERE id = 'pickup_stale_edit'),
+    'a checkout selection loaded before an edit is rejected without consuming inventory'
+);

--- a/supabase/tests/product_demand_history.sql
+++ b/supabase/tests/product_demand_history.sql
@@ -5,6 +5,10 @@ BEGIN
 END;
 $$;
 
+INSERT INTO public.pickup_windows (id, start_at, end_at, enabled)
+VALUES ('11111111-1111-4111-8111-111111111111', '2099-09-18T18:42:00-07:00', '2099-09-18T19:25:00-07:00', true)
+ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO public.categories (id, name, sort_order)
 VALUES ('demand-tests', 'Demand Tests', 900);
 INSERT INTO public.products (id, category_id, name, price_cents, max_per_order)
@@ -80,13 +84,15 @@ SELECT public.create_authoritative_order(
     'demand_sale', 'track_demand_sale',
     '{"name":"Demand Buyer","email":"buyer@example.com"}'::jsonb,
     '{"method":"cash"}'::jsonb,
-    '[{"productId":"demand-cake","quantity":3}]'::jsonb
+    '[{"productId":"demand-cake","quantity":3}]'::jsonb,
+    '11111111-1111-4111-8111-111111111111'
 );
 SELECT public.create_authoritative_order(
     'demand_canceled', 'track_demand_canceled',
     '{"name":"Canceled Buyer","email":"cancel@example.com"}'::jsonb,
     '{"method":"cash"}'::jsonb,
-    '[{"productId":"demand-cake","quantity":2}]'::jsonb
+    '[{"productId":"demand-cake","quantity":2}]'::jsonb,
+    '11111111-1111-4111-8111-111111111111'
 );
 SELECT public.cancel_order_and_restore_inventory('demand_canceled');
 UPDATE public.products SET is_archived = true WHERE id = 'demand-cake';


### PR DESCRIPTION
## Summary
- add concrete, minute-precise Pacific pickup windows managed from /admin/availability
- require a customer pickup selection and validate it inside the authoritative order/inventory transaction
- store immutable pickup snapshots for admin orders, public tracking, and notifications
- reject stale selections after disable, edit, or the 15-minute cutoff without consuming inventory

## Validation
- npm test — 41 files, 180 tests passed
- npm run test:db — passed
- npm run lint — passed
- npm run build — passed
- npm run test:smoke — passed
- git diff --check — passed

Closes #13