### PR TITLE
fix: restore reliable menu loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
+# Optional local-only menu fixture. Never used when NODE_ENV=production.
+# MENU_DATA_SOURCE=fixture
+
 # Venmo handle for checkout (e.g. @LittleTownBakes)
 NEXT_PUBLIC_VENMO_HANDLE=@LittleTownBakes
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [DEV_TODO.md](DEV_TODO.md) for a development checklist (Supabase project, mi
 | `NEXT_PUBLIC_SUPABASE_URL` | Yes | Supabase project URL |
 | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Yes | Supabase publishable key used by cookie-backed Auth clients |
 | `SUPABASE_SERVICE_ROLE_KEY` | Yes | Supabase service role key (server-only) |
+| `MENU_DATA_SOURCE` | No | Set to `fixture` only for deterministic local development/test menu data; production always uses Supabase |
 | `NEXT_PUBLIC_VENMO_HANDLE` | No | Venmo handle for checkout (default: @LittleTownBakes) |
 | `NOTIFICATIONS_ENABLED` | No | Set to `true` to enable configured server-side notification channels (default: disabled) |
 | `RESEND_API_KEY` | For email | Resend API key (server-only) |
@@ -54,6 +55,8 @@ Run migrations in order:
 ## Menu
 
 PostgreSQL tables `categories` and `products` are the authoritative catalog. Set `products.is_archived` to move an item between the current menu and Past Flavors. `product_inventory` stores one current `quantity_on_hand` per product; an active product at zero stays visible but cannot be ordered. The migration intentionally resets all prelaunch period inventory to zero.
+
+For local UI work without Supabase menu reads, set `MENU_DATA_SOURCE=fixture` in `.env.local` and run `npm run dev`. The committed `fixtures/menu.json` contains in-stock, sold-out, multi-category, and archived examples. Fixture selection is disabled whenever `NODE_ENV=production`, even if `MENU_DATA_SOURCE` is set, so deployed production builds continue to use the Supabase catalog and server-authoritative checkout.
 
 `product_demand_events` preserves anonymous demand for each sold-out or archived period. Database triggers open and close periods when inventory or archive state changes. Lifetime sales remain derived from non-canceled order snapshots and are not combined with demand.
 

--- a/app/api/menu/route.test.ts
+++ b/app/api/menu/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockFrom } = vi.hoisted(() => ({
 	mockFrom: vi.fn(),
@@ -63,12 +63,14 @@ function setDatabaseResults({
 	inventoryRows = [],
 	categoryError = null,
 	productError = null,
+	inventoryError = null,
 }: {
 	categoryRows?: unknown[];
 	productRows?: unknown[];
 	inventoryRows?: unknown[];
 	categoryError?: QueryResult["error"];
 	productError?: QueryResult["error"];
+	inventoryError?: QueryResult["error"];
 } = {}) {
 	mockFrom.mockImplementation((table: string) => {
 		if (table === "categories") {
@@ -78,7 +80,7 @@ function setDatabaseResults({
 			return { select: vi.fn().mockResolvedValue(queryResult(productRows, productError)) };
 		}
 		if (table === "product_inventory") {
-			return { select: vi.fn().mockResolvedValue(queryResult(inventoryRows)) };
+			return { select: vi.fn().mockResolvedValue(queryResult(inventoryRows, inventoryError)) };
 		}
 		throw new Error(`Unexpected table ${table}`);
 	});
@@ -87,7 +89,48 @@ function setDatabaseResults({
 describe("GET /api/menu", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.stubEnv("MENU_DATA_SOURCE", "");
 		setDatabaseResults();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("returns the deterministic fixture without querying Supabase when explicitly enabled", async () => {
+		vi.stubEnv("MENU_DATA_SOURCE", "fixture");
+
+		const response = await GET();
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(mockFrom).not.toHaveBeenCalled();
+		expect(body.categories.map((category: { id: string }) => category.id)).toEqual([
+			"cake-pops",
+			"cookies",
+		]);
+		expect(body.items.map((item: { id: string }) => item.id)).toEqual([
+			"birthday-cake-pop",
+			"chocolate-cake-pop",
+			"chocolate-chip-cookie",
+			"snickerdoodle-cookie",
+		]);
+		expect(body.items.find((item: { id: string }) => item.id === "snickerdoodle-cookie"))
+			.toMatchObject({ remaining: 0, available: false, availability: { inStock: false } });
+		expect(body.archivedItems.map((item: { id: string }) => item.id)).toEqual([
+			"red-velvet-cake-pop",
+		]);
+	});
+
+	it("does not select fixture data in production", async () => {
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("MENU_DATA_SOURCE", "fixture");
+
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		expect(mockFrom).toHaveBeenCalledWith("categories");
+		expect((await response.json()).items.map((item: { id: string }) => item.id)).toContain("apple-cake");
 	});
 
 	it("maps active database products into the existing API contract", async () => {
@@ -171,9 +214,23 @@ describe("GET /api/menu", () => {
 
 		const response = await GET();
 
-		expect(response.status).toBe(500);
-		expect(await response.json()).toEqual({ error: "Menu unavailable" });
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			error: "Menu is currently unavailable. Please try again later.",
+			code: "MENU_SOURCE_UNAVAILABLE",
+		});
 		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("returns a controlled error instead of silently marking everything sold out when inventory fails", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		setDatabaseResults({ inventoryError: { message: "inventory unavailable" } });
+
+		const response = await GET();
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toMatchObject({ code: "MENU_SOURCE_UNAVAILABLE" });
 		consoleError.mockRestore();
 	});
 });

--- a/app/api/menu/route.ts
+++ b/app/api/menu/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabaseAdmin";
-import type { Category, Item } from "@/lib/menuCatalog";
+import menuFixture from "@/fixtures/menu.json";
+import type { Category, Item, MenuResponse } from "@/lib/menuCatalog";
 import { getQuantityOnHand, type ProductInventory } from "@/lib/inventory";
 
 type CategoryRow = {
@@ -57,8 +58,22 @@ function mapProduct(row: ProductRow): Item {
 	};
 }
 
+function shouldUseMenuFixture({
+	nodeEnv = process.env.NODE_ENV,
+	menuDataSource = process.env.MENU_DATA_SOURCE,
+}: {
+	nodeEnv?: string;
+	menuDataSource?: string;
+} = {}): boolean {
+	return nodeEnv !== "production" && menuDataSource === "fixture";
+}
+
 export async function GET() {
 	try {
+		if (shouldUseMenuFixture()) {
+			return NextResponse.json(menuFixture satisfies MenuResponse);
+		}
+
 		const supabase = getSupabaseAdmin();
 		const [categoriesResult, productsResult, inventoryResult] = await Promise.all([
 			supabase.from("categories").select("id, name, sort_order"),
@@ -68,9 +83,12 @@ export async function GET() {
 			supabase.from("product_inventory").select("product_id, quantity_on_hand"),
 		]);
 
-		if (categoriesResult.error || productsResult.error) {
+		if (categoriesResult.error || productsResult.error || inventoryResult.error) {
 			throw new Error(
-				categoriesResult.error?.message ?? productsResult.error?.message ?? "Catalog query failed"
+				categoriesResult.error?.message
+					?? productsResult.error?.message
+					?? inventoryResult.error?.message
+					?? "Catalog query failed"
 			);
 		}
 
@@ -80,9 +98,7 @@ export async function GET() {
 		const catalogItems = ((productsResult.data ?? []) as ProductRow[])
 			.map(mapProduct)
 			.sort(compareCatalogEntries);
-		const inventory = inventoryResult.error
-			? []
-			: ((inventoryResult.data ?? []) as ProductInventory[]);
+		const inventory = (inventoryResult.data ?? []) as ProductInventory[];
 
 		const enrichedItems = catalogItems.map((item) => {
 			const remaining = getQuantityOnHand(inventory, item.id);
@@ -102,7 +118,13 @@ export async function GET() {
 			archivedItems: enrichedItems.filter((item) => item.isArchived),
 		});
 	} catch (error) {
-		console.error("[api/menu]", error);
-		return NextResponse.json({ error: "Menu unavailable" }, { status: 500 });
+		console.error("[api/menu] Failed to load the Supabase catalog", error);
+		return NextResponse.json(
+			{
+				error: "Menu is currently unavailable. Please try again later.",
+				code: "MENU_SOURCE_UNAVAILABLE",
+			},
+			{ status: 503 }
+		);
 	}
 }

--- a/components/menu/MenuBrowser.test.tsx
+++ b/components/menu/MenuBrowser.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadMenuCatalog } from "./MenuBrowser";
+
+const validCatalog = {
+	categories: [{ id: "cookies", name: "Cookies", sortOrder: 10 }],
+	items: [{
+		id: "cookie",
+		name: "Cookie",
+		categoryId: "cookies",
+		basePrice: 2,
+		availability: { inStock: true },
+		remaining: 4,
+		available: true,
+	}],
+	archivedItems: [],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("MenuBrowser menu loading", () => {
+	it("returns a successful menu response", async () => {
+		const fetchMenu = vi.fn().mockResolvedValue(jsonResponse(validCatalog));
+
+		await expect(loadMenuCatalog(fetchMenu)).resolves.toEqual(validCatalog);
+		expect(fetchMenu).toHaveBeenCalledWith("/api/menu", { cache: "no-store" });
+	});
+
+	it("surfaces the API message for a non-2xx response", async () => {
+		const fetchMenu = vi.fn().mockResolvedValue(jsonResponse({
+			error: "Menu is currently unavailable. Please try again later.",
+		}, 503));
+
+		await expect(loadMenuCatalog(fetchMenu)).rejects.toThrow(
+			"Menu is currently unavailable. Please try again later."
+		);
+	});
+
+	it("turns a rejected fetch into a visible connection error", async () => {
+		const fetchMenu = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+		await expect(loadMenuCatalog(fetchMenu)).rejects.toThrow(
+			"Could not connect to the menu. Please check your connection and try again."
+		);
+	});
+
+	it.each([
+		["non-JSON", new Response("upstream broke", { status: 200 })],
+		["invalid shape", jsonResponse({ categories: [], items: "not-an-array" })],
+	])("turns a %s response into a visible invalid-response error", async (_label, response) => {
+		const fetchMenu = vi.fn().mockResolvedValue(response);
+
+		await expect(loadMenuCatalog(fetchMenu)).rejects.toThrow(
+			"The menu service returned an invalid response. Please try again."
+		);
+	});
+});

--- a/components/menu/MenuBrowser.tsx
+++ b/components/menu/MenuBrowser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import type { MenuCatalog, Section, EnrichedItem } from "@/lib/menuCatalog";
+import type { MenuCatalog, MenuResponse, Section, EnrichedItem } from "@/lib/menuCatalog";
 import { buildSections, formatCurrency } from "@/lib/menuCatalog";
 import MenuSection from "./MenuSection";
 
@@ -33,6 +33,48 @@ function isItemAvailable(item: EnrichedItem): boolean {
 	return (item as EnrichedItem).available ?? item.availability.inStock;
 }
 
+function isMenuResponse(value: unknown): value is MenuResponse {
+	if (!value || typeof value !== "object") return false;
+
+	const response = value as Partial<MenuResponse>;
+	return Array.isArray(response.categories)
+		&& Array.isArray(response.items)
+		&& Array.isArray(response.archivedItems);
+}
+
+export async function loadMenuCatalog(fetchMenu: typeof fetch = fetch): Promise<MenuResponse> {
+	let response: Response;
+	try {
+		response = await fetchMenu("/api/menu", { cache: "no-store" });
+	} catch {
+		throw new Error("Could not connect to the menu. Please check your connection and try again.");
+	}
+
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new Error("The menu service returned an invalid response. Please try again.");
+	}
+
+	if (!response.ok) {
+		const apiError = data && typeof data === "object" && "error" in data
+			? (data as { error?: unknown }).error
+			: undefined;
+		throw new Error(
+			typeof apiError === "string" && apiError.trim()
+				? apiError
+				: "Menu is currently unavailable. Please try again later."
+		);
+	}
+
+	if (!isMenuResponse(data)) {
+		throw new Error("The menu service returned an invalid response. Please try again.");
+	}
+
+	return data;
+}
+
 export default function MenuBrowser({ onAddToCart, getQty, onSetQty }: MenuBrowserProps) {
 	const [catalog, setCatalog] = useState<MenuCatalog>({ categories: [], items: [] });
 	const [loading, setLoading] = useState(true);
@@ -43,15 +85,20 @@ export default function MenuBrowser({ onAddToCart, getQty, onSetQty }: MenuBrows
 		(async () => {
 			setLoading(true);
 			setError(null);
-			const res = await fetch("/api/menu", { cache: "no-store" });
-			const data = await res.json();
-			if (!alive) return;
-			if (!res.ok || (!data.categories?.length && !data.items?.length)) {
-				setError("Menu is currently unavailable");
-			} else {
+			try {
+				const data = await loadMenuCatalog();
+				if (!alive) return;
 				setCatalog(data);
+			} catch (loadError) {
+				if (!alive) return;
+				setError(
+					loadError instanceof Error
+						? loadError.message
+						: "Menu is currently unavailable. Please try again later."
+				);
+			} finally {
+				if (alive) setLoading(false);
 			}
-			setLoading(false);
 		})();
 		return () => {
 			alive = false;

--- a/fixtures/menu.json
+++ b/fixtures/menu.json
@@ -1,0 +1,98 @@
+{
+  "categories": [
+    {
+      "id": "cake-pops",
+      "name": "Cake Pops",
+      "sortOrder": 10
+    },
+    {
+      "id": "cookies",
+      "name": "Cookies",
+      "sortOrder": 20
+    }
+  ],
+  "items": [
+    {
+      "id": "birthday-cake-pop",
+      "name": "Birthday Cake Pop",
+      "categoryId": "cake-pops",
+      "description": "Vanilla cake and buttercream dipped in white chocolate with rainbow sprinkles.",
+      "basePrice": 2.5,
+      "image": "/img/cakepop_vanilla.png",
+      "maxPerOrder": 12,
+      "isArchived": false,
+      "sortOrder": 10,
+      "remaining": 8,
+      "available": true,
+      "availability": {
+        "inStock": true
+      }
+    },
+    {
+      "id": "chocolate-cake-pop",
+      "name": "Chocolate Cake Pop",
+      "categoryId": "cake-pops",
+      "description": "Rich chocolate cake dipped in dark chocolate and topped with sprinkles.",
+      "basePrice": 2.5,
+      "image": "/img/cakepop_chocolate.png",
+      "maxPerOrder": 12,
+      "isArchived": false,
+      "sortOrder": 20,
+      "remaining": 4,
+      "available": true,
+      "availability": {
+        "inStock": true
+      }
+    },
+    {
+      "id": "chocolate-chip-cookie",
+      "name": "Chocolate Chip Cookie",
+      "categoryId": "cookies",
+      "description": "A chewy cookie loaded with semisweet chocolate chips.",
+      "basePrice": 2,
+      "image": "/img/cookie_chocolatechip.png",
+      "maxPerOrder": 24,
+      "isArchived": false,
+      "sortOrder": 30,
+      "remaining": 12,
+      "available": true,
+      "availability": {
+        "inStock": true
+      }
+    },
+    {
+      "id": "snickerdoodle-cookie",
+      "name": "Snickerdoodle Cookie",
+      "categoryId": "cookies",
+      "description": "A soft cinnamon-sugar cookie that is temporarily sold out.",
+      "basePrice": 2,
+      "image": "/img/cookie_snickerdoodle.png",
+      "maxPerOrder": 24,
+      "isArchived": false,
+      "sortOrder": 40,
+      "remaining": 0,
+      "available": false,
+      "availability": {
+        "inStock": false
+      }
+    }
+  ],
+  "archivedItems": [
+    {
+      "id": "red-velvet-cake-pop",
+      "name": "Red Velvet Cake Pop",
+      "categoryId": "cake-pops",
+      "description": "A past flavor made with red velvet cake and cream cheese frosting.",
+      "basePrice": 2.75,
+      "image": "/img/cupcake_redvelvet.png",
+      "maxPerOrder": 12,
+      "isArchived": true,
+      "sortOrder": 50,
+      "remaining": 0,
+      "available": false,
+      "availability": {
+        "inStock": false
+      }
+    }
+  ]
+}

--- a/lib/menuCatalog.ts
+++ b/lib/menuCatalog.ts
@@ -34,6 +34,12 @@ export type MenuCatalog = {
     items: Item[];
 };
 
+export type MenuResponse = {
+	categories: Category[];
+	items: EnrichedItem[];
+	archivedItems: EnrichedItem[];
+};
+
 export type Section = {
     category: Category;
     items: Item[];


### PR DESCRIPTION
## Summary

- add an explicit development/test-only JSON menu fixture
- keep production permanently on the Supabase-backed catalog path
- return deliberate API failures for catalog and inventory outages
- surface non-2xx, rejected fetch, non-JSON, and malformed responses in MenuBrowser
- document local fixture mode

## Production incident

The configured Little Town Bakes Supabase project was inactive, so its hostname did not resolve and the Vercel route failed with `TypeError: fetch failed`. After restoring it, the project was still on the empty legacy schema with no catalog tables or migration history.

The existing tracked migrations were applied in order. Production readiness and `/api/menu` now both return HTTP 200 from the authoritative Supabase catalog. No fixture data is used in production.

## Fixture selection

Set `MENU_DATA_SOURCE=fixture` while running `npm run dev`. The route also requires `NODE_ENV` not to equal `production`; a production environment variable mistake therefore cannot select the fixture.

## Verification

- `npm test` — 42 files, 188 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm run test:smoke` — passed
- local development fixture `/api/menu` — HTTP 200 with in-stock, sold-out, and archived cases
- production `/api/health?ready=1` — HTTP 200, Supabase ok
- production `/api/menu` — HTTP 200 with 3 categories, 5 current products, and 1 archived product

Closes #26
