### PR TITLE
fix: make Past Flavors failures explicit

### DIFF
--- a/app/request-flavor/PastFlavorsContent.tsx
+++ b/app/request-flavor/PastFlavorsContent.tsx
@@ -1,0 +1,42 @@
+import { ArchivedFlavorCard, type ArchivedItem } from "@/components/menu/ArchivedFlavorCard";
+import { loadMenuCatalog } from "@/lib/loadMenuCatalog";
+
+type PastFlavorsContentProps = {
+	archivedItems: ArchivedItem[];
+	loading: boolean;
+	error: string | null;
+};
+
+export async function loadArchivedFlavors(fetchMenu: typeof fetch = fetch): Promise<ArchivedItem[]> {
+	const menu = await loadMenuCatalog(fetchMenu);
+	return menu.archivedItems;
+}
+
+export function PastFlavorsContent({
+	archivedItems,
+	loading,
+	error,
+}: PastFlavorsContentProps) {
+	if (loading) {
+		return <p role="status" aria-busy="true" className="text-sage">Loading past flavors...</p>;
+	}
+
+	if (error) {
+		return (
+			<div role="alert" className="rounded-lg border border-crust bg-wheat p-6 text-cocoa">
+				<p className="font-display text-lg font-semibold">Past flavors are temporarily unavailable.</p>
+				<p className="mt-2 text-sm text-sage">{error}</p>
+			</div>
+		);
+	}
+
+	if (archivedItems.length === 0) {
+		return <p className="text-sage">No past flavors at the moment. Check back later!</p>;
+	}
+
+	return (
+		<div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+			{archivedItems.map((item) => <ArchivedFlavorCard key={item.id} item={item} />)}
+		</div>
+	);
+}

--- a/app/request-flavor/page.test.tsx
+++ b/app/request-flavor/page.test.tsx
@@ -1,12 +1,72 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
-import { ArchivedFlavorCard } from "@/components/menu/ArchivedFlavorCard";
-import RequestFlavorPage from "./page";
+import { describe, expect, it, vi } from "vitest";
+import {
+	loadArchivedFlavors,
+	PastFlavorsContent,
+} from "./PastFlavorsContent";
+
+const activeItem = {
+	id: "current-cookie",
+	name: "Current Cookie",
+	categoryId: "cookies",
+	basePrice: 2,
+	availability: { inStock: true },
+	remaining: 4,
+	available: true,
+};
+
+const archivedItems = [
+	{
+		...activeItem,
+		id: "red-velvet",
+		name: "Red Velvet",
+		description: "Cream cheese frosting.",
+		image: "/img/red-velvet.png",
+		isArchived: true,
+		remaining: 0,
+		available: false,
+		availability: { inStock: false },
+	},
+	{
+		...activeItem,
+		id: "lemon",
+		name: "Lemon",
+		isArchived: true,
+		remaining: 0,
+		available: false,
+		availability: { inStock: false },
+	},
+];
+
+const validCatalog = {
+	categories: [{ id: "cookies", name: "Cookies", sortOrder: 10 }],
+	items: [activeItem],
+	archivedItems,
+};
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function renderContent(props: Parameters<typeof PastFlavorsContent>[0]) {
+	return renderToStaticMarkup(createElement(PastFlavorsContent, props));
+}
 
 describe("Past Flavors page", () => {
+	it("shows an accessible loading state while the menu is requested", () => {
+		const html = renderContent({ archivedItems: [], loading: true, error: null });
+
+		expect(html).toContain('role="status"');
+		expect(html).toContain('aria-busy="true"');
+		expect(html).toContain("Loading past flavors");
+	});
+
 	it("does not collect contact details or promise notifications", () => {
-		const html = renderToStaticMarkup(createElement(RequestFlavorPage));
+		const html = renderContent({ archivedItems: [], loading: false, error: null });
 		expect(html).not.toContain('type="email"');
 		expect(html).not.toContain("Your name");
 		expect(html).not.toContain("Notes");
@@ -14,13 +74,58 @@ describe("Past Flavors page", () => {
 		expect(html).not.toContain("let you know");
 	});
 
-	it("offers the anonymous archived-product demand action", () => {
-		const html = renderToStaticMarkup(createElement(ArchivedFlavorCard, {
-			item: { id: "cake", name: "Chocolate Cake" },
-		}));
+	it("renders archived products deterministically with their details and demand action", () => {
+		const html = renderContent({ archivedItems, loading: false, error: null });
+
+		expect(html.indexOf("Red Velvet")).toBeLessThan(html.indexOf("Lemon"));
+		expect(html).toContain("Cream cheese frosting.");
+		expect(html).toContain('src="/img/red-velvet.png"');
 		expect(html).toContain("Bring this back");
+		expect(html).not.toContain("Current Cookie");
 		expect(html).not.toContain("email");
 		expect(html).not.toContain("name");
 		expect(html).not.toContain("notes");
+	});
+
+	it("shows the genuine empty state only after a successful empty response", () => {
+		const html = renderContent({ archivedItems: [], loading: false, error: null });
+
+		expect(html).toContain("No past flavors at the moment");
+		expect(html).not.toContain('role="alert"');
+	});
+
+	it("shows a deliberate error state instead of the empty state", () => {
+		const html = renderContent({
+			archivedItems: [],
+			loading: false,
+			error: "Menu is currently unavailable. Please try again later.",
+		});
+
+		expect(html).toContain('role="alert"');
+		expect(html).toContain("Menu is currently unavailable");
+		expect(html).not.toContain("No past flavors at the moment");
+	});
+
+	it("loads archived products without including active products", async () => {
+		const fetchMenu = vi.fn().mockResolvedValue(jsonResponse(validCatalog));
+
+		await expect(loadArchivedFlavors(fetchMenu)).resolves.toEqual(archivedItems);
+		expect(fetchMenu).toHaveBeenCalledWith("/api/menu", { cache: "no-store" });
+	});
+
+	it.each([
+		["a non-2xx response", jsonResponse({ error: "Menu unavailable" }, 500)],
+		["malformed JSON", new Response("not JSON", { status: 200 })],
+		["a malformed response", jsonResponse({ categories: [], items: [] })],
+	])("rejects %s instead of treating it as an empty archive", async (_label, response) => {
+		const fetchMenu = vi.fn().mockResolvedValue(response);
+
+		await expect(loadArchivedFlavors(fetchMenu)).rejects.toThrow();
+	});
+
+	it("rejects a failed request instead of treating it as an empty archive", async () => {
+		const fetchMenu = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+		await expect(loadArchivedFlavors(fetchMenu)).rejects.toThrow("Could not connect to the menu");
 	});
 });

--- a/app/request-flavor/page.tsx
+++ b/app/request-flavor/page.tsx
@@ -2,18 +2,36 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArchivedFlavorCard, type ArchivedItem } from "@/components/menu/ArchivedFlavorCard";
-
+import type { ArchivedItem } from "@/components/menu/ArchivedFlavorCard";
+import { loadArchivedFlavors, PastFlavorsContent } from "./PastFlavorsContent";
 
 export default function RequestFlavorPage() {
 	const [archivedItems, setArchivedItems] = useState<ArchivedItem[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		fetch("/api/menu")
-			.then((response) => response.json())
-			.then((data) => setArchivedItems(data.archivedItems ?? []))
-			.finally(() => setLoading(false));
+		let alive = true;
+
+		(async () => {
+			try {
+				const items = await loadArchivedFlavors();
+				if (alive) setArchivedItems(items);
+			} catch (loadError) {
+				if (!alive) return;
+				setError(
+					loadError instanceof Error
+						? loadError.message
+						: "Menu is currently unavailable. Please try again later."
+				);
+			} finally {
+				if (alive) setLoading(false);
+			}
+		})();
+
+		return () => {
+			alive = false;
+		};
 	}, []);
 
 	return (
@@ -22,13 +40,7 @@ export default function RequestFlavorPage() {
 			<h1 className="mb-2 font-display text-3xl font-semibold text-cocoa">Past Flavors</h1>
 			<p className="mb-8 text-sage">Flavors we&apos;ve retired. Miss one? Send the baker a quick anonymous signal.</p>
 
-			{loading ? <p className="text-sage">Loading...</p> : archivedItems.length === 0 ? (
-				<p className="text-sage">No past flavors at the moment. Check back later!</p>
-			) : (
-				<div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-					{archivedItems.map((item) => <ArchivedFlavorCard key={item.id} item={item} />)}
-				</div>
-			)}
+			<PastFlavorsContent archivedItems={archivedItems} loading={loading} error={error} />
 		</main>
 	);
 }

--- a/components/menu/MenuBrowser.test.tsx
+++ b/components/menu/MenuBrowser.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadMenuCatalog } from "./MenuBrowser";
+import { loadMenuCatalog } from "@/lib/loadMenuCatalog";
 
 const validCatalog = {
 	categories: [{ id: "cookies", name: "Cookies", sortOrder: 10 }],

--- a/components/menu/MenuBrowser.tsx
+++ b/components/menu/MenuBrowser.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import type { MenuCatalog, MenuResponse, Section, EnrichedItem } from "@/lib/menuCatalog";
+import type { MenuCatalog, Section, EnrichedItem } from "@/lib/menuCatalog";
 import { buildSections, formatCurrency } from "@/lib/menuCatalog";
+import { loadMenuCatalog } from "@/lib/loadMenuCatalog";
 import MenuSection from "./MenuSection";
 
 type MenuBrowserProps = {
@@ -31,48 +32,6 @@ type MenuBrowserProps = {
 
 function isItemAvailable(item: EnrichedItem): boolean {
 	return (item as EnrichedItem).available ?? item.availability.inStock;
-}
-
-function isMenuResponse(value: unknown): value is MenuResponse {
-	if (!value || typeof value !== "object") return false;
-
-	const response = value as Partial<MenuResponse>;
-	return Array.isArray(response.categories)
-		&& Array.isArray(response.items)
-		&& Array.isArray(response.archivedItems);
-}
-
-export async function loadMenuCatalog(fetchMenu: typeof fetch = fetch): Promise<MenuResponse> {
-	let response: Response;
-	try {
-		response = await fetchMenu("/api/menu", { cache: "no-store" });
-	} catch {
-		throw new Error("Could not connect to the menu. Please check your connection and try again.");
-	}
-
-	let data: unknown;
-	try {
-		data = await response.json();
-	} catch {
-		throw new Error("The menu service returned an invalid response. Please try again.");
-	}
-
-	if (!response.ok) {
-		const apiError = data && typeof data === "object" && "error" in data
-			? (data as { error?: unknown }).error
-			: undefined;
-		throw new Error(
-			typeof apiError === "string" && apiError.trim()
-				? apiError
-				: "Menu is currently unavailable. Please try again later."
-		);
-	}
-
-	if (!isMenuResponse(data)) {
-		throw new Error("The menu service returned an invalid response. Please try again.");
-	}
-
-	return data;
 }
 
 export default function MenuBrowser({ onAddToCart, getQty, onSetQty }: MenuBrowserProps) {

--- a/lib/loadMenuCatalog.ts
+++ b/lib/loadMenuCatalog.ts
@@ -1,0 +1,43 @@
+import type { MenuResponse } from "@/lib/menuCatalog";
+
+function isMenuResponse(value: unknown): value is MenuResponse {
+	if (!value || typeof value !== "object") return false;
+
+	const response = value as Partial<MenuResponse>;
+	return Array.isArray(response.categories)
+		&& Array.isArray(response.items)
+		&& Array.isArray(response.archivedItems);
+}
+
+export async function loadMenuCatalog(fetchMenu: typeof fetch = fetch): Promise<MenuResponse> {
+	let response: Response;
+	try {
+		response = await fetchMenu("/api/menu", { cache: "no-store" });
+	} catch {
+		throw new Error("Could not connect to the menu. Please check your connection and try again.");
+	}
+
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new Error("The menu service returned an invalid response. Please try again.");
+	}
+
+	if (!response.ok) {
+		const apiError = data && typeof data === "object" && "error" in data
+			? (data as { error?: unknown }).error
+			: undefined;
+		throw new Error(
+			typeof apiError === "string" && apiError.trim()
+				? apiError
+				: "Menu is currently unavailable. Please try again later."
+		);
+	}
+
+	if (!isMenuResponse(data)) {
+		throw new Error("The menu service returned an invalid response. Please try again.");
+	}
+
+	return data;
+}


### PR DESCRIPTION
## Summary

- share the validated `/api/menu` client loader between the current menu and Past Flavors
- add explicit loading, success, empty, and error states for archived products
- keep active products out of Past Flavors while preserving the anonymous demand action
- add regression coverage for successful, empty, failed, rejected, and malformed responses

## Root cause

PR #35 restored the shared menu data source, so archived products load in production again. However, the Past Flavors page still parsed every response as successful and defaulted missing `archivedItems` to an empty array. API failures could therefore look like a legitimate empty archive, while rejected fetches and malformed JSON were not handled deliberately.

## Verification

- `npm test` — 42 files, 196 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- local fixture browser smoke — `/api/menu` returned HTTP 200 and Red Velvet Cake Pop rendered with its description and Bring this back action
- browser console — no errors

Closes #28
